### PR TITLE
Show available spots

### DIFF
--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -121,6 +121,7 @@ $string['choice_active'] = 'Choice active';
 $string['choice_active_help'] = 'Your choice gets displayed to your users only while its active. Inactive choices won\'t display';
 $string['choice_explanation'] = 'Explanation (additional) Text';
 $string['choice_maxsize'] = 'Max. number of members';
+$string['choice_maxsize_display'] = 'Maximum number of students';
 $string['choice_title'] = 'Title';
 $string['choice_title_help'] = 'Title of the choice. *Attention* all available choices will be outputted ordered by title.';
 $string['edit_choice'] = 'Edit Choice {$a}';

--- a/locallib.php
+++ b/locallib.php
@@ -806,7 +806,7 @@ class ratingallocate {
      * @return multitype:
      */
     public function get_rating_data_for_user($userid) {
-        $sql = "SELECT c.id as choiceid, c.title, c.explanation, c.ratingallocateid, r.rating, r.id AS ratingid, r.userid
+        $sql = "SELECT c.id as choiceid, c.title, c.explanation, c.ratingallocateid, c.maxsize, r.rating, r.id AS ratingid, r.userid
                 FROM {ratingallocate_choices} c
            LEFT JOIN {ratingallocate_ratings} r
                   ON c.id = r.choiceid and r.userid = :userid

--- a/locallib.php
+++ b/locallib.php
@@ -190,37 +190,37 @@ class ratingallocate {
         }
     }
     
-    private function process_action_give_rating(){
-        // Get current time
+    private function process_action_give_rating() {
+        // Get current time.
         $now = time();
-        $output='';
+        $output = '';
         /* @var $renderer mod_ratingallocate_renderer */
         $renderer = $this->get_renderer();
-        // Print data and controls for students, but not for admins
+        // Print data and controls for students, but not for admins.
         if (has_capability('mod/ratingallocate:give_rating', $this->context, null, false)) {
-            global $DB,$PAGE,$USER;
-            // if no choice option exists WARN!
+            global $DB, $PAGE, $USER;
+            // If no choice option exists WARN!
             if (!$DB->record_exists('ratingallocate_choices', array('ratingallocateid' => $this->ratingallocateid))) {
                 $renderer->add_notification(get_string('no_choice_to_rate', ratingallocate_MOD_NAME));
-            }
-            // rating possible
-            else if ($this->ratingallocate->accesstimestart < $now && $this->ratingallocate->accesstimestop > $now) {
+            } else if ($this->ratingallocate->accesstimestart < $now && $this->ratingallocate->accesstimestop > $now) {
+                // Rating is possible...
+
                 // suche das richtige Formular nach Strategie
                 /* @var $strategyform ratingallocate_viewform */
                 $strategyform = 'ratingallocate\\' . $this->ratingallocate->strategy . '\\mod_ratingallocate_view_form';
                 /* @var $mform ratingallocate_strategyform */
                 $mform = new $strategyform($PAGE->url->out(), $this);
-        
-                // save submitted data and call default page
+
+                // Save submitted data and call default page.
                 if ($mform->is_submitted() && $mform->is_validated() && !$mform->is_cancelled() && $data = $mform->get_data() ) {
 
                         $this->save_ratings_to_db($USER->id, $data->data);
                         $renderer->add_notification(get_string('ratings_saved', ratingallocate_MOD_NAME), self::NOTIFY_SUCCESS);
                         return $this->process_default();
                 }
-        
+
                 $output .= $renderer->render_ratingallocate_strategyform($mform);
-                //Logging
+                // Logging.
                 $event = \mod_ratingallocate\event\rating_viewed::create_simple(
                         context_course::instance($this->course->id), $this->ratingallocateid);
                 $event->trigger();
@@ -255,7 +255,7 @@ class ratingallocate {
         return $output;
     }
     
-    private function process_action_show_alloc_table(){
+    private function process_action_show_alloc_table() {
         $output = '';
         // Print ratings table
         if (has_capability('mod/ratingallocate:start_distribution', $this->context)) {

--- a/strategy/strategy_template_options.php
+++ b/strategy/strategy_template_options.php
@@ -74,11 +74,9 @@ abstract class ratingallocate_options_strategyform extends \ratingallocate_strat
             // Show max. number of allocations.
             // TODO add setting in order to make this optional, as requested in issue #14.
             $mform->addElement('html', '<div class="mod-ratingallocate-choice-maxno">' .
-                '<span class="mod-ratingallocate-choice-maxno-desc">' . get_string('choice_maxsize_display', ratingallocate_MOD_NAME) .
+                '<span class="mod-ratingallocate-choice-maxno-desc">' .
+                get_string('choice_maxsize_display', ratingallocate_MOD_NAME) .
                 ':</span> <span class="mod-ratingallocate-choice-maxno-value">' . $data->maxsize . '</span></div>');
-
-            // Show explanation.
-            $mform->addElement('html', '<div>' . $data->explanation . '</div>');
 
             // Options for each choice.
             $choiceoptions = $this->get_choiceoptions();
@@ -91,7 +89,8 @@ abstract class ratingallocate_options_strategyform extends \ratingallocate_strat
             $radioarray = $this->ratingallocate->prepare_horizontal_radio_choice($radioarray, $mform);
 
             // It is important to set a group name, so that later on errors can be displayed at the correct spot.
-            $mform->addGroup($radioarray, 'radioarr_' . $data->choiceid, '', null, false);
+            // Furthermore, use explanation as title/label of group.
+            $mform->addGroup($radioarray, 'radioarr_' . $data->choiceid, $data->explanation, null, false);
 
             $maxrating = max(array_keys($choiceoptions));
             // Try to restore previous ratings.

--- a/strategy/strategy_template_options.php
+++ b/strategy/strategy_template_options.php
@@ -68,14 +68,14 @@ abstract class ratingallocate_options_strategyform extends \ratingallocate_strat
             $mform->setType($groupsidelem, PARAM_INT);
 
             // Show title.
-            $title = $data->title;
-            // Append max. no of members.
-            // TODO add setting in order to make this optional, as requested in issue #14.
-            $title .= " (" . get_string('choice_maxsize', ratingallocate_MOD_NAME) .
-                ": " . $data->maxsize . ")";
-
-            $mform->addElement('header', $headerelem, $title);
+            $mform->addElement('header', $headerelem, $data->title);
             $mform->setExpanded($headerelem);
+
+            // Show max. number of allocations.
+            // TODO add setting in order to make this optional, as requested in issue #14.
+            $mform->addElement('html', '<div class="mod-ratingallocate-choice-maxno">' .
+                '<span class="mod-ratingallocate-choice-maxno-desc">' . get_string('choice_maxsize_display', ratingallocate_MOD_NAME) .
+                ':</span> <span class="mod-ratingallocate-choice-maxno-value">' . $data->maxsize . '</span></div>');
 
             // Show explanation.
             $mform->addElement('html', '<div>' . $data->explanation . '</div>');

--- a/strategy/strategy_template_options.php
+++ b/strategy/strategy_template_options.php
@@ -67,8 +67,14 @@ abstract class ratingallocate_options_strategyform extends \ratingallocate_strat
             $mform->addElement('hidden', $groupsidelem, $data->choiceid);
             $mform->setType($groupsidelem, PARAM_INT);
 
-            // show title
-            $mform->addElement('header', $headerelem, $data->title);
+            // Show title.
+            $title = $data->title;
+            // Append max. no of members.
+            // TODO add setting in order to make this optional, as requested in issue #14.
+            $title .= " (" . get_string('choice_maxsize', ratingallocate_MOD_NAME) .
+                ": " . $data->maxsize . ")";
+
+            $mform->addElement('header', $headerelem, $title);
             $mform->setExpanded($headerelem);
 
             // show explanation

--- a/strategy/strategy_template_options.php
+++ b/strategy/strategy_template_options.php
@@ -31,7 +31,7 @@ require_once(dirname(__FILE__) . '/../locallib.php');
 require_once(dirname(__FILE__) . '/strategy_template.php');
 
 abstract class strategytemplate_options extends \strategytemplate {
-   
+
     /**
      * Return the different options for each choice (including titles)
      * @return array: value_of_option => title_of_option
@@ -46,7 +46,7 @@ abstract class strategytemplate_options extends \strategytemplate {
  * - shows a drop down menu from which the user can choose a rating
  */
 abstract class ratingallocate_options_strategyform extends \ratingallocate_strategyform {
-    
+
     /**
      * Defines forms elements
      */
@@ -63,7 +63,7 @@ abstract class ratingallocate_options_strategyform extends \ratingallocate_strat
             $ratingelem = $elemprefix . '[rating]';
             $groupsidelem = $elemprefix . '[choiceid]';
 
-            // save choiceid
+            // Save choiceid.
             $mform->addElement('hidden', $groupsidelem, $data->choiceid);
             $mform->setType($groupsidelem, PARAM_INT);
 
@@ -77,28 +77,28 @@ abstract class ratingallocate_options_strategyform extends \ratingallocate_strat
             $mform->addElement('header', $headerelem, $title);
             $mform->setExpanded($headerelem);
 
-            // show explanation
+            // Show explanation.
             $mform->addElement('html', '<div>' . $data->explanation . '</div>');
 
-            // options for each choice
+            // Options for each choice.
             $choiceoptions = $this->get_choiceoptions();
 
             $radioarray = array();
             foreach ($choiceoptions as $id => $option) {
                 $radioarray [] =& $mform->createElement('radio', $ratingelem, '', $option, $id);
             }
-            // Adding static elements to support css
+            // Adding static elements to support css.
             $radioarray = $this->ratingallocate->prepare_horizontal_radio_choice($radioarray, $mform);
-            
-            // it is important to set a group name, so that later on errors can be displayed at the correct spot.
+
+            // It is important to set a group name, so that later on errors can be displayed at the correct spot.
             $mform->addGroup($radioarray, 'radioarr_' . $data->choiceid, '', null, false);
 
-            $max_rating = max(array_keys($choiceoptions));
-            // try to restore previous ratings
-            if (is_numeric($data->rating) && $data->rating >= 0 && $data->rating <= $max_rating) {
+            $maxrating = max(array_keys($choiceoptions));
+            // Try to restore previous ratings.
+            if (is_numeric($data->rating) && $data->rating >= 0 && $data->rating <= $maxrating) {
                 $mform->setDefault($ratingelem, $data->rating);
             } else {
-                $mform->setDefault($ratingelem, $max_rating);
+                $mform->setDefault($ratingelem, $maxrating);
             }
             // $mform->setType($ratingelem, PARAM_INT);
         }
@@ -128,17 +128,18 @@ abstract class ratingallocate_options_strategyform extends \ratingallocate_strat
         if ($impossibles > $maxno) {
             foreach ($ratings as $cid => $rating) {
                 if ($rating ['rating'] == 0) {
-                    $errors ['radioarr_' . $cid] = get_string($this->get_max_nos_string_identyfier(), ratingallocate_MOD_NAME, $maxno);
+                    $errors ['radioarr_' . $cid] = get_string($this->get_max_nos_string_identyfier(),
+                        ratingallocate_MOD_NAME, $maxno);
                 }
             }
         }
         return $errors;
     }
-    
+
     public abstract function get_choiceoptions();
 
     protected abstract function get_max_amount_of_nos();
-    //TODO remove and make identifier strategy_options specific not strategy specific
+    // TODO remove and make identifier strategy_options specific not strategy specific.
     protected abstract function get_max_nos_string_identyfier();
 
 }

--- a/styles.css
+++ b/styles.css
@@ -3,3 +3,6 @@
 .ratingallocate_ratings_table td.ratingallocate_member {
     border: solid black 5px;
     background-image: repeating-linear-gradient(45deg, white 0px, white 15px, transparent 15px, transparent 30px, white 30px); }
+.path-mod-ratingallocate .mod-ratingallocate-choice-maxno {
+    text-align: right;
+}


### PR DESCRIPTION
Display max. number of members per choice to user.
In the course of writing this, I changed two files so that they adhere to the moodle code style guidelines.

This resolves #14 as discussed there. That is, currently the number of available spots is always displayed. If this should be optional, a further issue needs to be opened.