### PR TITLE
Enable horizontal scrolling on very large "Ratings and Allocations" table

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,3 +3,4 @@
 .ratingallocate_ratings_table td.ratingallocate_member {
     border: solid black 5px;
     background-image: repeating-linear-gradient(45deg, white 0px, white 15px, transparent 15px, transparent 30px, white 30px); }
+.ratingallocate_ratings_box { overflow: auto; } /* Scrolling tables */


### PR DESCRIPTION
A scroll bar is displayed for tables that extend much to the right
Resolves #34.