### PR TITLE
Fix: Cancelling of Rating

### DIFF
--- a/strategy/strategy_template.php
+++ b/strategy/strategy_template.php
@@ -251,8 +251,6 @@ abstract class ratingallocate_strategyform extends \moodleform  {
     public function to_html() {
         /* usually $mform->display() is called which echos the form instead of returning it */
         $o = '';
-        $this->add_action_buttons();
-        $this->definition_after_data();
         $o .= $this->_form->getValidationScript();
         $o .= $this->_form->toHtml();
         return $o;


### PR DESCRIPTION
Enable redirect (w/o saving) on cancel. Fixes #43.

The problem here was that the `submit` and `cancel` buttons were defined only shortly before output. At that point, all form validation and potential saving on submit were already done; i.e. the form did not know about the existence of a `cancel` button yet.

Furthermore, the relevant functions now adhere to the Moodle code style.