### PR TITLE
Use a language string for the name of groupings.

### DIFF
--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -35,6 +35,7 @@ $string['modulename_help'] = 'The ratingallocate module lets you define choices 
 $string['modulenameplural'] = 'ratingallocates';
 $string['pluginadministration'] = 'ratingallocate administration';
 $string['pluginname'] = 'ratingallocate';
+$string['groupingname'] = 'Created from Ratingallocate "{$a}"';
 $string['ratingallocate:addinstance'] = 'Add new instance of ratingallocate';
 $string['ratingallocate:view'] = 'View instances of ratingallocate';
 $string['ratingallocate:give_rating'] = 'Create or edit choice';

--- a/locallib.php
+++ b/locallib.php
@@ -350,7 +350,7 @@ class ratingallocate {
             if (!$grouping) {
                 // create grouping
                 $data = new stdClass();
-                $data->name = 'created from ' . $this->ratingallocate->name;
+                $data->name = get_string('groupingname', ratingallocate_MOD_NAME, $this->ratingallocate->name);
                 $data->idnumber = $groupingidname;
                 $data->courseid = $this->course->id;
                 $groupingid = groups_create_grouping($data);


### PR DESCRIPTION
Until now, the name was hardcoded as `created from` + name of the ratingallocate activity.