### PR TITLE
Use the title of an instance as page title.

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -43,7 +43,6 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
     public function render_ratingallocate_header(ratingallocate_header $header) {
         $o = '';
 
-        $this->page->set_title(get_string('pluginname', ratingallocate_MOD_NAME));
         $this->page->set_heading($this->page->course->fullname);
         $this->page->requires->css('/mod/ratingallocate/styles.css');
 

--- a/view.php
+++ b/view.php
@@ -51,6 +51,7 @@ if ($id) {
 
 require_login($course, true, $cm);
 $context = context_module::instance($cm->id);
+$PAGE->set_title($cm->name);
 $PAGE->set_context($context);
 $PAGE->set_url('/mod/ratingallocate/view.php', array('id' => $cm->id));
 


### PR DESCRIPTION
Until now, the title of any Ratingallocate page was ``ratingallocate``, which is not very nice. Now, the page title is the name of the instance, as displayed in the course.