### PR TITLE
Simplify fetching course data.

### DIFF
--- a/classes/task/send_distribution_notification.php
+++ b/classes/task/send_distribution_notification.php
@@ -42,7 +42,7 @@ class send_distribution_notification extends \core\task\adhoc_task {
         $ratingallocate = $DB->get_record(this_db\ratingallocate::TABLE,array(this_db\ratingallocate::ID=>$ratingallocateid),'*', MUST_EXIST);
         
         $courseid = $ratingallocate->course;
-        $course = $DB->get_record('course', array('id' => $courseid));
+        $course = get_course($courseid);
         $cm = get_coursemodule_from_instance('ratingallocate', $ratingallocate->id, $courseid);
         $context = \context_module::instance($cm->id);
 

--- a/export_ratings_csv.php
+++ b/export_ratings_csv.php
@@ -30,9 +30,7 @@ $id = required_param('id', PARAM_INT); // course_module ID, or
 
 if ($id) {
     $cm = get_coursemodule_from_id('ratingallocate', $id, 0, false, MUST_EXIST);
-    $course = $DB->get_record('course', array(
-        'id' => $cm->course
-            ), '*', MUST_EXIST);
+    $course = get_course($cm->course);
     $ratingallocate = $DB->get_record('ratingallocate', array(
         'id' => $cm->instance
             ), '*', MUST_EXIST);

--- a/index.php
+++ b/index.php
@@ -34,7 +34,7 @@ require_once(dirname(__FILE__).'/locallib.php');
 
 $id = required_param('id', PARAM_INT);   // course
 
-$course = $DB->get_record('course', array('id' => $id), '*', MUST_EXIST);
+$course = get_course($id);
 
 require_course_login($course);
 

--- a/solver/export_lp_solve.php
+++ b/solver/export_lp_solve.php
@@ -33,9 +33,7 @@ $action = optional_param('action', '', PARAM_ACTION);
 
 if ($id) {
     $cm = get_coursemodule_from_id('ratingallocate', $id, 0, false, MUST_EXIST);
-    $course = $DB->get_record('course', array(
-        'id' => $cm->course
-            ), '*', MUST_EXIST);
+    $course = get_course($cm->course);
     $ratingallocate = $DB->get_record('ratingallocate', array(
         'id' => $cm->instance
             ), '*', MUST_EXIST);

--- a/view.php
+++ b/view.php
@@ -38,11 +38,11 @@ $n  = optional_param('m', 0, PARAM_INT);  // ratingallocate instance ID - it sho
 
 if ($id) {
     $cm         = get_coursemodule_from_id('ratingallocate', $id, 0, false, MUST_EXIST);
-    $course     = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
+    $course     = get_course($cm->course);
     $ratingallocate  = $DB->get_record('ratingallocate', array('id' => $cm->instance), '*', MUST_EXIST);
 } else if ($n) {
     $ratingallocate  = $DB->get_record('ratingallocate', array('id' => $n), '*', MUST_EXIST);
-    $course     = $DB->get_record('course', array('id' => $ratingallocate->course), '*', MUST_EXIST);
+    $course     = get_course($ratingallocate->course);
     $cm         = get_coursemodule_from_instance('ratingallocate', $ratingallocate->id, $course->id, false, MUST_EXIST);
 } else {
     error('You must specify a course_module ID or an instance ID');


### PR DESCRIPTION
Closes #47 as suggested by @abias (#47):
> Replace: `$course = $DB->get_record('course', array('id' => $courseid), '*', MUST_EXIST);`
> With: `$course = get_course($courseid);`

This causes courses to be loaded from cache - instead of fetching them from db - if possible.