### PR TITLE
Sort headings to align them with exported data.

### DIFF
--- a/export_ratings_csv.php
+++ b/export_ratings_csv.php
@@ -67,6 +67,9 @@ foreach ($choices as $choice) {
     $exporttitle [($choice->id + $offsetchoices)] = $choice->id . '|' . $choice->title;
 }
 
+// Sort headings by (choice-)id to align them with exported data (created below).
+ksort($exporttitle);
+
 $exporttitle [] = "allocation";
 $columnid ["allocation"] = key(array_slice($exporttitle, - 1, 1, true));
 


### PR DESCRIPTION
Although the data columns where reordered by ID, this was never done for the column headers.

Now they are ordered in an identical way. Fixes #65.