### PR TITLE
fixes #95 updates links in events' get_url methods

### DIFF
--- a/classes/event/allocation_published.php
+++ b/classes/event/allocation_published.php
@@ -57,7 +57,7 @@ class allocation_published extends \core\event\base {
     }
  
     public function get_url() {
-        return new \moodle_url('/mod/ratingallocate/view.php', array('ratingallocate' => $this->objectid));
+        return new \moodle_url('/mod/ratingallocate/view.php', array('m' => $this->objectid));
     }
 
     public static function get_objectid_mapping() {

--- a/classes/event/allocation_statistics_viewed.php
+++ b/classes/event/allocation_statistics_viewed.php
@@ -51,7 +51,7 @@ class allocation_statistics_viewed extends \core\event\base {
     }
  
     public function get_url() {
-        return new \moodle_url('/mod/ratingallocate/view.php', array('ratingallocate' => $this->objectid));
+        return new \moodle_url('/mod/ratingallocate/view.php', array('m' => $this->objectid));
     }
 
     public static function get_objectid_mapping() {

--- a/classes/event/allocation_table_viewed.php
+++ b/classes/event/allocation_table_viewed.php
@@ -51,7 +51,7 @@ class allocation_table_viewed extends \core\event\base {
     }
  
     public function get_url() {
-        return new \moodle_url('/mod/ratingallocate/view.php', array('ratingallocate' => $this->objectid));
+        return new \moodle_url('/mod/ratingallocate/view.php', array('m' => $this->objectid));
     }
 
     public static function get_objectid_mapping() {

--- a/classes/event/distribution_triggered.php
+++ b/classes/event/distribution_triggered.php
@@ -62,7 +62,7 @@ class distribution_triggered extends \core\event\base {
     }
  
     public function get_url() {
-        return new \moodle_url('/mod/ratingallocate/view.php', array('ratingallocate' => $this->objectid));
+        return new \moodle_url('/mod/ratingallocate/view.php', array('m' => $this->objectid));
     }
 
     public static function get_objectid_mapping() {

--- a/classes/event/manual_allocation_saved.php
+++ b/classes/event/manual_allocation_saved.php
@@ -56,7 +56,7 @@ class manual_allocation_saved extends \core\event\base {
     }
  
     public function get_url() {
-        return new \moodle_url('/mod/ratingallocate/view.php', array('ratingallocate' => $this->objectid));
+        return new \moodle_url('/mod/ratingallocate/view.php', array('m' => $this->objectid));
     }
 
     public static function get_objectid_mapping() {

--- a/classes/event/rating_saved.php
+++ b/classes/event/rating_saved.php
@@ -59,7 +59,7 @@ class rating_saved extends \core\event\base {
     }
  
     public function get_url() {
-        return new \moodle_url('/mod/ratingallocate/view.php', array('ratingallocate' => $this->objectid));
+        return new \moodle_url('/mod/ratingallocate/view.php', array('m' => $this->objectid));
     }
 
     public static function get_objectid_mapping() {

--- a/classes/event/rating_viewed.php
+++ b/classes/event/rating_viewed.php
@@ -51,7 +51,7 @@ class rating_viewed extends \core\event\base {
     }
  
     public function get_url() {
-        return new \moodle_url('/mod/ratingallocate/view.php', array('ratingallocate' => $this->objectid));
+        return new \moodle_url('/mod/ratingallocate/view.php', array('m' => $this->objectid));
     }
 
     public static function get_objectid_mapping() {

--- a/classes/event/ratingallocate_viewed.php
+++ b/classes/event/ratingallocate_viewed.php
@@ -51,7 +51,7 @@ class ratingallocate_viewed extends \core\event\base {
     }
  
     public function get_url() {
-        return new \moodle_url('/mod/ratingallocate/view.php', array('ratingallocate' => $this->objectid));
+        return new \moodle_url('/mod/ratingallocate/view.php', array('m' => $this->objectid));
     }
 
     public static function get_objectid_mapping() {


### PR DESCRIPTION
The query param name needs to be `m` not `ratingallocate` when pointing at `view.php`.
This first commit only addresses the events that use `ratingallocate` as the events' `objecttable`. 
Some other events (`distribution_triggered`, `manual_allocation_saved`, `rating_saved`) use other `objecttable` values and therefore the contained `objectid` may not be the right value to use. 