### PR TITLE
Improved language strings

### DIFF
--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -64,7 +64,7 @@ $string['no_choice_to_rate'] = 'There are no choices to rate!';
 $string['at_least_one_rateable_choices_needed'] = 'You need at least one rateable choice.';
 // </editor-fold>
 // <editor-fold defaultstate="collapsed" desc="Administrator View">
-$string['allocation_manual_explain_only_raters'] = 'Select a choice to be assigned to a user. 
+$string['allocation_manual_explain_only_raters'] = 'Select a choice to be assigned to a user.
 Only users who rated at least one choice and who are not allocated yet are listed.';
 $string['allocation_manual_explain_all'] = 'Select a choice to be assigned to a user.';
 $string['distribution_algorithm'] = 'Distribution Algorithm';
@@ -185,8 +185,8 @@ $string['runalgorithmbycron_help'] = 'Automatically runs the allocation algorith
 $string['select_strategy'] = 'Rating strategy';
 $string['select_strategy_help'] = 'Choose a rating strategy:
 
-* **Yes-No** The user can rate each choice with yes or no.
-* **Yes-Maybe-No** The user can rate each choice with yes, maybe or no.
+* **Accept-Deny** The user can decide for each choice to accept or deny it.
+* **Accept-Neutral-Deny** The user can decide for each choice to accept or deny or to be neutral about it.
 * **Likert Scale** The user can rate each choice with a number from a defined range. The range of numbers can be defined individually (beginning with 0). A high number corresponds to a high preference.
 * **Give Points** The user can rate the choices by assigning a number of points. The maximum number of points can be defined individually. A high number of points corresponds to a high preference.
 * **Rank Choices** The user has to rank the available choices. How many choices need to be rated can be defined individually.
@@ -211,21 +211,21 @@ $string['choice_table_tools'] = 'Edit';
 $string['strategy_settings_label'] = 'Designation for "{$a}"';
 
 /* Specific to Strategy01, YesNo */
-$string['strategy_yesno_name'] = 'Yes-No';
-$string['strategy_yesno_setting_crossout'] = 'Maximum number of choices the user can rate with "No"';
-$string['strategy_yesno_max_no'] = 'You may only assign "No" to {$a} choice(s).';
-$string['strategy_yesno_maximum_crossout'] = 'You may only assign "No" to at most {$a} choice(s).';
-$string['strategy_yesno_rating_crossout'] = 'No';
-$string['strategy_yesno_rating_choose'] = 'Yes';
+$string['strategy_yesno_name'] = 'Accept-Deny';
+$string['strategy_yesno_setting_crossout'] = 'Maximum number of choices the user can rate with "Deny"';
+$string['strategy_yesno_max_no'] = 'You may only assign "Deny" to {$a} choice(s).';
+$string['strategy_yesno_maximum_crossout'] = 'You may only assign "Deny" to at most {$a} choice(s).';
+$string['strategy_yesno_rating_crossout'] = 'Deny';
+$string['strategy_yesno_rating_choose'] = 'Accept';
 
 /* Specific to Strategy02, YesMayBeNo */
-$string['strategy_yesmaybeno_name'] = 'Yes-Maybe-No';
-$string['strategy_yesmaybeno_setting_maxno'] = 'Maximum number of choices the user can rate with "No"';
-$string['strategy_yesmaybeno_max_no'] = 'You may only assign "No" to {$a} choice(s).';
-$string['strategy_yesmaybeno_max_count_no'] = 'You may only assign "No" to at most {$a} choice(s).';
-$string['strategy_yesmaybeno_rating_no'] = 'No';
-$string['strategy_yesmaybeno_rating_maybe'] = 'Maybe';
-$string['strategy_yesmaybeno_rating_yes'] = 'Yes';
+$string['strategy_yesmaybeno_name'] = 'Accept-Neutral-Deny';
+$string['strategy_yesmaybeno_setting_maxno'] = 'Maximum number of choices the user can rate with "Deny"';
+$string['strategy_yesmaybeno_max_no'] = 'You may only assign "Deny" to {$a} choice(s).';
+$string['strategy_yesmaybeno_max_count_no'] = 'You may only assign "Deny" to at most {$a} choice(s).';
+$string['strategy_yesmaybeno_rating_no'] = 'Deny';
+$string['strategy_yesmaybeno_rating_maybe'] = 'Neutral';
+$string['strategy_yesmaybeno_rating_yes'] = 'Accept';
 
 // Specific to Strategy03, Likert
 $string['strategy_lickert_name'] = 'Likert Scale';

--- a/tests/behat/select_strategy.feature
+++ b/tests/behat/select_strategy.feature
@@ -18,9 +18,9 @@ Feature: When a teacher selects a strategy the appropriate options are displayed
 
   @javascript
   Scenario: The correct options are displayed for the default strategy (Yes-No)
-    Then the field "Rating strategy" matches value "Yes-No"
-    And I should see "Maximum number of choices the user can rate with \"No\""
-    And I should see "Designation for \"No\""
+    Then the field "Rating strategy" matches value "Accept-Deny"
+    And I should see "Maximum number of choices the user can rate with \"Deny\""
+    And I should see "Designation for \"Deny\""
 
   @javascript
   Scenario: Selecting "Likert Scale" strategy should show the correct options.
@@ -28,8 +28,8 @@ Feature: When a teacher selects a strategy the appropriate options are displayed
     Then I should see "Maximum number of choices the user can rate with 0"
     And I should see "Highest number on the likert scale"
     And I should see "Designation for \"0 - Exclude\""
-    And I should not see "Maximum number of choices the user can rate with \"No\""
-    And I should not see "Designation for \"No\""
+    And I should not see "Maximum number of choices the user can rate with \"Deny\""
+    And I should not see "Designation for \"Deny\""
 
   @javascript
   Scenario: Selecting "Give Points" then "Yes-No" shows only the correct options.
@@ -37,7 +37,7 @@ Feature: When a teacher selects a strategy the appropriate options are displayed
     And I should see "Maximum number of choices to which the user can give 0 points"
     And I should see "Total number of points the user can assign"
     And I select "strategy_yesno" from the "strategy" singleselect
-    Then I should see "Maximum number of choices the user can rate with \"No\""
-    And I should see "Designation for \"No\""
+    Then I should see "Maximum number of choices the user can rate with \"Deny\""
+    And I should see "Designation for \"Deny\""
     And I should not see "Maximum number of choices to which the user can give 0 points"
     And I should not see "Total number of points the user can assign"

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -147,7 +147,7 @@ class locallib_test extends advanced_testcase {
      * Test if option titles are returned according to the default values
      */
     public function test_get_option_titles_default() {
-        $expectedresult = array(1 => 'Yes', 0 => 'No'); // Depends on language file.
+        $expectedresult = array(1 => 'Accept', 0 => 'Deny'); // Depends on language file.
         $ratings = array(0, 1, 1, 1, 0);
 
         $record = mod_ratingallocate_generator::get_default_values();
@@ -200,7 +200,7 @@ class locallib_test extends advanced_testcase {
         $settings = array(1 => 'Ja1234'); // Test data.
         $ratings = array(0, 1, 1, 1, 1);
         $expectedresult = $settings;
-        $expectedresult [0] = 'No'; // Depends on language file.
+        $expectedresult [0] = 'Deny'; // Depends on language file.
 
         $record = mod_ratingallocate_generator::get_default_values();
         $record['strategyopt']['strategy_yesno'] = $settings;


### PR DESCRIPTION
A user saw that in the german translation the naming of the rating
strategies are different to those in the related help. And we thought
that the german translation might be a little better, so I changed the
strings here in the original file to be more speaking. What do you
think about it?