### PR TITLE
Transformed links on view.php to buttons

### DIFF
--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -306,7 +306,7 @@ $string['log_allocation_statistics_viewed'] = 'Allocation statistics viewed';
 $string['log_allocation_statistics_viewed_description'] =  'The user with id "{$a->userid}" viewed the allocation statistics for the Fair Allocation with id "{$a->ratingallocateid}".';
 
 $string['log_index_viewed'] = 'User viewed all instances of Fair Allocation';
-$string['log_index_viewed_description'] =  'The user with id "{$a->userid}" viewed all instances of Fair Allocation in this course".';
+$string['log_index_viewed_description'] =  'The user with id "{$a->userid}" viewed all instances of Fair Allocation in this course.';
 
 
 $string['no_id_or_m_error'] = 'You must specify a course_module ID or an instance ID';

--- a/renderer.php
+++ b/renderer.php
@@ -352,15 +352,13 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
 
         $tableurl = new moodle_url($PAGE->url, array('action' => ACTION_SHOW_ALLOC_TABLE));
 
-        // Link to display information about the allocations and ratings
-        $output .= $this->action_link($tableurl->out(), get_string('show_table', ratingallocate_MOD_NAME));
-
-        $output .= html_writer::empty_tag('br', array());
+        // Button with link to display information about the allocations and ratings
+        $output .= $this->single_button($tableurl, get_string('show_table', ratingallocate_MOD_NAME));
 
         $tableurl = new moodle_url($PAGE->url, array('action' => ACTION_SHOW_STATISTICS));
 
-        // Link to display statistical information about the allocations
-        $output .= $this->action_link($tableurl->out(), get_string('show_allocation_statistics', ratingallocate_MOD_NAME));
+        // Buttton with link to display statistical information about the allocations
+        $output .= $this->single_button($tableurl, get_string('show_allocation_statistics', ratingallocate_MOD_NAME));
 
         /* TODO: File not readable
         $output .= html_writer::empty_tag('br', array());


### PR DESCRIPTION
This relates to #132.
On /mod/ratingallocate/view.php?id=, there are buttons in all sections except the last "Reports" section. I transformed them into singlebuttons and removed the <br/> tag to be arranged the same way as the buttons of the other sections are.