### PR TITLE
Added explanation to the section " Your Allocation"

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -186,6 +186,7 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
             foreach ($status->allocations as $allocation) {
                 $allocation_html .= '<li>';
                 $allocation_html .= format_string($allocation->{this_db\ratingallocate_choices::TITLE});
+                $allocation_html .= '<br/>' . format_string($allocation->{this_db\ratingallocate_choices::EXPLANATION});
                 $allocation_html .= '</li>';
             }
             $allocation_html = '<ul>' . $allocation_html . '</ul>';


### PR DESCRIPTION
We did not add the explanations to the listings of the choices as this may become very huge.
So we added it only to the section "Your allocation". 
Right now, this is only added in a new line after the choice title. There may be some more work to improve the design of it.