### PR TITLE
Added default option for rating form

### DIFF
--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -230,6 +230,10 @@ $string['is_published'] = 'Published';
 
 $string['strategy_settings_label'] = 'Designation for "{$a}"';
 
+$string['strategy_settings_default'] = 'Default value for rating form';
+$string['strategy_settings_default_help'] = 'The rating form, the users are provided with, will contain a set of radio buttons for each available choice.
+This value defines the default value the radio buttons are initialized with.';
+
 /* Specific to Strategy01, YesNo */
 $string['strategy_yesno_name'] = 'Accept-Deny';
 $string['strategy_yesno_setting_crossout'] = 'Maximum number of choices the user can rate with "Deny"';

--- a/mod_form.php
+++ b/mod_form.php
@@ -113,7 +113,7 @@ class mod_ratingallocate_mod_form extends moodleform_mod {
 
         $elementname = 'publishdate';
         $mform->addElement('date_time_selector', $elementname, get_string($elementname, self::MOD_NAME),
-                $options = array('optional' => true));
+                array('optional' => true));
         $mform->setDefault($elementname, time() + 9 * 24 * 60 * 60);
 
         $elementname = 'runalgorithmbycron';
@@ -154,10 +154,10 @@ class mod_ratingallocate_mod_form extends moodleform_mod {
      * @param string $stratfieldid id of the element to be added
      * @param array $value array with the element type and its caption 
      *        (usually returned by the strategys get settingsfields methods).
-     * @param string $curr_strategyid id of the strategy it belongs to
-     * @param string $default default value for the element
+     * @param string $strategyid id of the strategy it belongs to.
+     * @param $mform MoodleQuickForm form object the settings field should be added to.
      */
-    private function add_settings_field($stratfieldid, array $value, $strategyid, MoodleQuickForm $mform, $default = null) {
+    private function add_settings_field($stratfieldid, array $value, $strategyid, MoodleQuickForm $mform) {
 
         $attributes = array('size' => '20');
 

--- a/mod_form.php
+++ b/mod_form.php
@@ -161,7 +161,7 @@ class mod_ratingallocate_mod_form extends moodleform_mod {
 
         $attributes = array('size' => '20');
 
-        if (isset($value[3])) {
+        if ($value[0] != "select" && isset($value[3])) {
             $attributes['placeholder'] = ($value[3]);
         }
 
@@ -172,9 +172,14 @@ class mod_ratingallocate_mod_form extends moodleform_mod {
             $mform->addElement('text', $stratfieldid, $value[1], $attributes);
             $mform->setType($stratfieldid, PARAM_TEXT);
             $mform->addRule($stratfieldid, null, 'numeric'); // TODO: Only validate if not disabled.
+        } else if ($value[0] == "select") {
+            $mform->addElement('select', $stratfieldid, $value[1], $value[3], $attributes);
         }
         if (isset($value[2])) {
             $mform->setDefault($stratfieldid, $value[2]);
+        }
+        if (isset($value[4])) {
+            $mform->addHelpButton($stratfieldid, $value[4], self::MOD_NAME);
         }
         $mform->disabledIf($stratfieldid, 'strategy', 'neq', $strategyid);
     }

--- a/strategy/strategy01_yes_no.php
+++ b/strategy/strategy01_yes_no.php
@@ -43,7 +43,7 @@ class strategy extends \strategytemplate_options {
     }
 
     public function get_static_settingfields() {
-        $output =  array(
+        $output = array(
             self::MAXCROSSOUT => array(
                 'int',
                 get_string(self::STRATEGYID . '_setting_crossout', ratingallocate_MOD_NAME),
@@ -51,7 +51,7 @@ class strategy extends \strategytemplate_options {
                 null
             )
         );
-        foreach($this->get_choiceoptions() as $id => $option){
+        foreach (array_keys($this->get_choiceoptions()) as $id) {
             $output[$id] = array(
                             'text',
                             get_string('strategy_settings_label', ratingallocate_MOD_NAME, $this->get_settings_default_value($id)),
@@ -62,28 +62,28 @@ class strategy extends \strategytemplate_options {
         $output += $this->get_default_strategy_option(1);
         return $output;
     }
-    
-    public function get_dynamic_settingfields(){
+
+    public function get_dynamic_settingfields() {
         return array();
     }
-    
-    public function get_choiceoptions(){
+
+    public function get_choiceoptions() {
         $options = array(
-            0 => $this->get_settings_value(0), 
+            0 => $this->get_settings_value(0),
             1 => $this->get_settings_value(1)
         );
         return $options;
     }
 
-    public function get_default_settings(){
+    public function get_default_settings() {
         return array(
                         self::MAXCROSSOUT => 3,
-                        0 => get_string(strategy::STRATEGYID . '_rating_crossout', ratingallocate_MOD_NAME),
-                        1 => get_string(strategy::STRATEGYID . '_rating_choose', ratingallocate_MOD_NAME)
+                        0 => get_string(self::STRATEGYID . '_rating_crossout', ratingallocate_MOD_NAME),
+                        1 => get_string(self::STRATEGYID . '_rating_choose', ratingallocate_MOD_NAME)
         );
     }
-    
-    protected function getValidationInfo(){
+
+    protected function getValidationInfo() {
         return array(self::MAXCROSSOUT => array(true,0));
     }
 }
@@ -92,16 +92,16 @@ class strategy extends \strategytemplate_options {
 \strategymanager::add_strategy(strategy::STRATEGYID);
 
 class mod_ratingallocate_view_form extends \ratingallocate_options_strategyform {
-    //Already specified by parent class
+    // Already specified by parent class
 
-    protected function construct_strategy($strategyoptions){
+    protected function construct_strategy($strategyoptions) {
         return new strategy($strategyoptions);
     }
-    
+
     public function get_choiceoptions() {
         return $this->get_strategy()->get_choiceoptions();
     }
-    
+
     protected function get_max_amount_of_nos() {
         return $this->get_strategysetting(strategy::MAXCROSSOUT);
     }

--- a/strategy/strategy01_yes_no.php
+++ b/strategy/strategy01_yes_no.php
@@ -28,7 +28,6 @@
 
 namespace ratingallocate\strategy_yesno;
 
-use ratingallocate\strategy_yesno\strategy;
 defined('MOODLE_INTERNAL') || die();
 require_once($CFG->libdir . '/formslib.php');
 require_once(dirname(__FILE__) . '/../locallib.php');
@@ -60,6 +59,7 @@ class strategy extends \strategytemplate_options {
                             $this->get_settings_default_value($id)
             );
         }
+        $output += $this->get_default_strategy_option();
         return $output;
     }
     

--- a/strategy/strategy01_yes_no.php
+++ b/strategy/strategy01_yes_no.php
@@ -59,7 +59,7 @@ class strategy extends \strategytemplate_options {
                             $this->get_settings_default_value($id)
             );
         }
-        $output += $this->get_default_strategy_option();
+        $output += $this->get_default_strategy_option(1);
         return $output;
     }
     

--- a/strategy/strategy02_yes_maybe_no.php
+++ b/strategy/strategy02_yes_maybe_no.php
@@ -42,7 +42,7 @@ class strategy extends \strategytemplate_options {
     public function get_strategyid() {
         return self::STRATEGYID;
     }
-    
+
     public function get_static_settingfields() {
         $output = array(
             self::MAXNO => array(// maximale Anzahl 'kannnicht'
@@ -52,7 +52,7 @@ class strategy extends \strategytemplate_options {
                 null
             )
         );
-        foreach($this->get_choiceoptions() as $id => $option){
+        foreach (array_keys($this->get_choiceoptions()) as $id) {
             $output[$id] = array(
                             'text',
                             get_string('strategy_settings_label', ratingallocate_MOD_NAME, $this->get_settings_default_value($id)),
@@ -64,28 +64,28 @@ class strategy extends \strategytemplate_options {
         return $output;
     }
 
-    public function get_dynamic_settingfields(){
+    public function get_dynamic_settingfields() {
         return array();
     }
 
     public function get_choiceoptions() {
         $options = array(
-            0 => $this->get_settings_value(0), 
-            3 => $this->get_settings_value(3), 
+            0 => $this->get_settings_value(0),
+            3 => $this->get_settings_value(3),
             5 => $this->get_settings_value(5)
         );
         return $options;
     }
 
-    public function get_default_settings(){
+    public function get_default_settings() {
         return array(
                         self::MAXNO => 3,
-                        0 => get_string(strategy::STRATEGYID . '_rating_no', ratingallocate_MOD_NAME),
-                        3 => get_string(strategy::STRATEGYID . '_rating_maybe', ratingallocate_MOD_NAME),
-                        5 => get_string(strategy::STRATEGYID . '_rating_yes', ratingallocate_MOD_NAME)
+                        0 => get_string(self::STRATEGYID . '_rating_no', ratingallocate_MOD_NAME),
+                        3 => get_string(self::STRATEGYID . '_rating_maybe', ratingallocate_MOD_NAME),
+                        5 => get_string(self::STRATEGYID . '_rating_yes', ratingallocate_MOD_NAME)
         );
     }
-    protected function getValidationInfo(){
+    protected function getValidationInfo() {
         return array(self::MAXNO => array(true,0));
     }
 }
@@ -94,16 +94,16 @@ class strategy extends \strategytemplate_options {
 \strategymanager::add_strategy(strategy::STRATEGYID);
 
 class mod_ratingallocate_view_form extends \ratingallocate_options_strategyform {
-    //Already specified by parent class
+    // Already specified by parent class
 
-    protected function construct_strategy($strategyoptions){
+    protected function construct_strategy($strategyoptions) {
         return new strategy($strategyoptions);
     }
-    
+
     public function get_choiceoptions() {
         return $this->get_strategy()->get_choiceoptions();
     }
-    
+
     protected function get_max_amount_of_nos() {
         return $this->get_strategysetting(strategy::MAXNO);
     }

--- a/strategy/strategy02_yes_maybe_no.php
+++ b/strategy/strategy02_yes_maybe_no.php
@@ -29,7 +29,6 @@
 
 namespace ratingallocate\strategy_yesmaybeno;
 
-use ratingallocate\strategy_yesmaybeno\strategy;
 defined('MOODLE_INTERNAL') || die();
 require_once($CFG->libdir . '/formslib.php');
 require_once(dirname(__FILE__) . '/../locallib.php');
@@ -61,6 +60,7 @@ class strategy extends \strategytemplate_options {
                             $this->get_settings_default_value($id)
             );
         }
+        $output += $this->get_default_strategy_option();
         return $output;
     }
 

--- a/strategy/strategy02_yes_maybe_no.php
+++ b/strategy/strategy02_yes_maybe_no.php
@@ -60,7 +60,7 @@ class strategy extends \strategytemplate_options {
                             $this->get_settings_default_value($id)
             );
         }
-        $output += $this->get_default_strategy_option();
+        $output += $this->get_default_strategy_option(2);
         return $output;
     }
 

--- a/strategy/strategy03_lickert.php
+++ b/strategy/strategy03_lickert.php
@@ -80,6 +80,7 @@ class strategy extends \strategytemplate_options {
                 $this->get_settings_default_value($id)
             );
         }
+        $output += $this->get_default_strategy_option();
         return $output;
     }
 

--- a/strategy/strategy03_lickert.php
+++ b/strategy/strategy03_lickert.php
@@ -80,7 +80,7 @@ class strategy extends \strategytemplate_options {
                 $this->get_settings_default_value($id)
             );
         }
-        $output += $this->get_default_strategy_option();
+        $output += $this->get_default_strategy_option(max(array_keys($this->get_choiceoptions())));
         return $output;
     }
 

--- a/strategy/strategy03_lickert.php
+++ b/strategy/strategy03_lickert.php
@@ -44,8 +44,9 @@ class strategy extends \strategytemplate_options {
         parent::__construct($strategy_settings);
         if (isset($strategy_settings) && array_key_exists(self::COUNTLICKERT, $strategy_settings)) {
             $this->maxlickert = $strategy_settings[self::COUNTLICKERT];
-        } else
+        } else {
             $this->maxlickert = $this->get_default_settings()[self::COUNTLICKERT];
+        }
     }
 
     public function get_strategyid() {
@@ -69,10 +70,10 @@ class strategy extends \strategytemplate_options {
         );
     }
 
-    
-    public function get_dynamic_settingfields(){
+
+    public function get_dynamic_settingfields() {
         $output = array();
-        foreach($this->get_choiceoptions() as $id => $option){
+        foreach (array_keys($this->get_choiceoptions()) as $id) {
             $output[$id] = array(
                 'text',
                 get_string('strategy_settings_label', ratingallocate_MOD_NAME, $this->get_settings_default_value($id)),
@@ -109,8 +110,8 @@ class strategy extends \strategytemplate_options {
         }
         return $defaults;
     }
-    
-    protected function getValidationInfo(){
+
+    protected function getValidationInfo() {
         return array(self::MAXNO => array(true,0),
                      self::COUNTLICKERT => array(true,2)
         );
@@ -121,12 +122,12 @@ class strategy extends \strategytemplate_options {
 \strategymanager::add_strategy(strategy::STRATEGYID);
 
 class mod_ratingallocate_view_form extends \ratingallocate_options_strategyform {
-    //Already specified by parent class
+    // Already specified by parent class
 
-    protected function construct_strategy($strategyoptions){
+    protected function construct_strategy($strategyoptions) {
         return new strategy($strategyoptions);
     }
-    
+
     public function get_choiceoptions() {
         $params = $this->get_strategysetting(strategy::COUNTLICKERT);
         return $this->get_strategy()->get_choiceoptions($params);

--- a/strategy/strategy04_points.php
+++ b/strategy/strategy04_points.php
@@ -48,32 +48,32 @@ class strategy extends \strategytemplate {
     public function get_static_settingfields() {
         return array(
             self::MAXZERO => array( // maximale Anzahl 'kannnicht'
-                'int', 
-                get_string(self::STRATEGYID . '_setting_maxzero', ratingallocate_MOD_NAME), 
+                'int',
+                get_string(self::STRATEGYID . '_setting_maxzero', ratingallocate_MOD_NAME),
                 $this->get_settings_value(self::MAXZERO),
                 null
-            ), 
+            ),
             self::TOTALPOINTS => array( // wie viele Felder es gibt
-                'int', 
-                get_string(self::STRATEGYID . '_setting_totalpoints', ratingallocate_MOD_NAME), 
+                'int',
+                get_string(self::STRATEGYID . '_setting_totalpoints', ratingallocate_MOD_NAME),
                 $this->get_settings_value(self::TOTALPOINTS),
                 null
             )
         );
     }
-    
-    public function get_dynamic_settingfields(){
+
+    public function get_dynamic_settingfields() {
         return array();
     }
-    
-    public function get_default_settings(){
+
+    public function get_default_settings() {
         return array(
                         self::MAXZERO => 3,
                         self::TOTALPOINTS => 100
         );
     }
-    
-    protected function getValidationInfo(){
+
+    protected function getValidationInfo() {
         return array(self::MAXZERO => array(true,0),
                      self::TOTALPOINTS => array(true,1)
         );
@@ -86,10 +86,10 @@ class strategy extends \strategytemplate {
 
 class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
 
-    protected function construct_strategy($strategyoptions){
+    protected function construct_strategy($strategyoptions) {
         return new strategy($strategyoptions);
     }
-    
+
     public function definition() {
         global $USER;
         parent::definition();

--- a/strategy/strategy05_order.php
+++ b/strategy/strategy05_order.php
@@ -47,18 +47,18 @@ class strategy extends \strategytemplate {
         return array(
             self::COUNTOPTIONS => array(// wie viele Felder es gibt
                 'int',
-                get_string(self::STRATEGYID . '_setting_countoptions', ratingallocate_MOD_NAME), 
+                get_string(self::STRATEGYID . '_setting_countoptions', ratingallocate_MOD_NAME),
                 $this->get_settings_value(self::COUNTOPTIONS),
                 null
             )
         );
     }
-    
-    public function get_dynamic_settingfields(){
+
+    public function get_dynamic_settingfields() {
         return array();
     }
-    
-    public function get_default_settings(){
+
+    public function get_default_settings() {
         $default_count_options = 2;
         $output = array(
                         self::COUNTOPTIONS => $default_count_options
@@ -69,12 +69,12 @@ class strategy extends \strategytemplate {
         }
         // $rating_value_counter defines the id/value of the label (first choice has a high value)
         for ($i = 1, $rating_value_counter = $count_options; $i <= $count_options; $i++,$rating_value_counter--) {
-            $output[$rating_value_counter] =  get_string(strategy::STRATEGYID . '_no_choice', ratingallocate_MOD_NAME, $i);
+            $output[$rating_value_counter] = get_string(self::STRATEGYID . '_no_choice', ratingallocate_MOD_NAME, $i);
         }
         return $output;
     }
-    
-    protected function getValidationInfo(){
+
+    protected function getValidationInfo() {
         return array(self::COUNTOPTIONS => array(true,1)
         );
     }
@@ -91,11 +91,11 @@ class strategy extends \strategytemplate {
  * - shows a drop down menu from which the user can choose a rating
  */
 class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
-    
-    protected function construct_strategy($strategyoptions){
+
+    protected function construct_strategy($strategyoptions) {
         return new strategy($strategyoptions);
     }
-    
+
     public function definition() {
         global $USER;
         parent::definition();
@@ -151,7 +151,7 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
         $select->setLabel(get_string(strategy::STRATEGYID . '_no_choice', ratingallocate_MOD_NAME, $i));
         $select->addOption(get_string(strategy::STRATEGYID . '_choice_none', ratingallocate_MOD_NAME, $i),
             '', array('disabled' => 'disabled'));
-        foreach ( $choices as $id => $name ) {
+        foreach ($choices as $id => $name) {
             $select->addOption( $name, $id );
         }
         $select->setSelected('');

--- a/strategy/strategy06_tickyes.php
+++ b/strategy/strategy06_tickyes.php
@@ -46,39 +46,39 @@ class strategy extends \strategytemplate {
 
     public function get_static_settingfields() {
         $output = array(
-            self::MINTICKYES => array('int', 
-                get_string(self::STRATEGYID . '_setting_mintickyes', ratingallocate_MOD_NAME), 
+            self::MINTICKYES => array('int',
+                get_string(self::STRATEGYID . '_setting_mintickyes', ratingallocate_MOD_NAME),
                 $this->get_settings_value(self::MINTICKYES)
             )
         );
-        
+
         $output[1] = array(
                         'text',
                         get_string('strategy_settings_label', ratingallocate_MOD_NAME, $this->get_settings_default_value(1)),
                         null,
                         $this->get_settings_default_value(1)
-                        
+
         );
         return $output;
     }
-    
-    public function get_dynamic_settingfields(){
+
+    public function get_dynamic_settingfields() {
         return array();
     }
-    
-    public function get_accept_label(){
+
+    public function get_accept_label() {
         return $this->get_settings_value(1);
     }
 
-    public function get_default_settings(){
+    public function get_default_settings() {
         return array(
                         self::MINTICKYES => 3,
                         1 => get_string(self::STRATEGYID . '_' . self::ACCEPT_LABEL, ratingallocate_MOD_NAME),
                         0 => get_string(self::STRATEGYID . '_not_' . self::ACCEPT_LABEL, ratingallocate_MOD_NAME)
         );
     }
-    
-    protected function getValidationInfo(){
+
+    protected function getValidationInfo() {
         return array(self::MINTICKYES => array(true,1)
         );
     }
@@ -95,10 +95,10 @@ class strategy extends \strategytemplate {
  */
 class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
 
-    protected function construct_strategy($strategyoptions){
+    protected function construct_strategy($strategyoptions) {
         return new strategy($strategyoptions);
     }
-    
+
     public function definition() {
         global $USER;
         parent::definition();
@@ -126,7 +126,6 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
                 '<span class="mod-ratingallocate-choice-maxno-desc">' .
                 get_string('choice_maxsize_display', ratingallocate_MOD_NAME) .
                 ':</span> <span class="mod-ratingallocate-choice-maxno-value">' . $data->maxsize . '</span></div>');
-
 
             // Use explanation as title/label of checkbox to align with other strategies.
             $mform->addElement('advcheckbox', $ratingelem, $data->explanation, $this->get_strategy()->get_accept_label(), null, array(0, 1));

--- a/strategy/strategy_template.php
+++ b/strategy/strategy_template.php
@@ -96,6 +96,8 @@ abstract class strategytemplate {
      * * Value[1]: Label of the settingsfield
      * * Value[2]: Default value (may be null)
      * * Value[3]: Placeholder text (may be null)
+     * * Value[3]: Placeholder text in case of 'text' or 'int' and options in case of 'select' (may be null)
+     * * Value[4]: String for the help_icon without _help suffix. (may be null)
      * }
      */
     public abstract function get_static_settingfields();

--- a/strategy/strategy_template.php
+++ b/strategy/strategy_template.php
@@ -79,10 +79,11 @@ abstract class strategytemplate {
      * If any dynamic Settingsfields is returned, a refresh button will be included in the view.
      * Return object:
      * array{
-     * * Value[0]: Type of settingsfield (e.g. 'text', 'int')
+     * * Value[0]: Type of settingsfield (e.g. 'text', 'int', 'select')
      * * Value[1]: Label of the settingsfield
      * * Value[2]: Default value (may be null)
-     * * Value[3]: Placeholder text (may be null)
+     * * Value[3]: Placeholder text in case of 'text' or 'int' and options in case of 'select' (may be null)
+     * * Value[4]: String for the help_icon without _help suffix. (may be null)
      * }
      */
     public abstract function get_dynamic_settingfields();

--- a/strategy/strategy_template.php
+++ b/strategy/strategy_template.php
@@ -38,29 +38,29 @@ abstract class strategytemplate {
     const STRATEGYID = '';
 
     private $_strategy_settings;
-    
-    public function __construct(array $strategy_settings = null){
+
+    public function __construct(array $strategy_settings = null) {
         $this->_strategy_settings = $strategy_settings;
     }
-    
+
     /**
      * Retrieves the value of a settings field.
      * @param $key of the settings field\
      * @return either the value of the setting the strategy was initialized with or the default value of the setting.
      */
-    protected function get_settings_value($key, $default = true){
+    protected function get_settings_value($key, $default = true) {
         if (isset($this->_strategy_settings) && array_key_exists($key, $this->_strategy_settings) && $this->_strategy_settings[$key] !== '') {
             return $value = $this->_strategy_settings[$key];
         }
         return $default ? $this->get_settings_default_value($key) : null;
     }
-    
+
     /**
      * Retrieves the default value of a settings field.
      * @param $key of the settings field\
      * @return the default value of the setting.
      */
-    protected function get_settings_default_value($key){
+    protected function get_settings_default_value($key) {
         $value = null;
         if (array_key_exists($key, $this->get_default_settings())) {
             $value = $this->get_default_settings()[$key];
@@ -73,7 +73,7 @@ abstract class strategytemplate {
      * @return array of key-value pairs of the settings
      */
     public abstract function get_default_settings();
-    
+
     /**
      * Return the dynamic Settingsfields the strategy needes
      * If any dynamic Settingsfields is returned, a refresh button will be included in the view.
@@ -110,22 +110,22 @@ abstract class strategytemplate {
     }
 
     public abstract function get_strategyid();
-    
+
     /**
-     * Searches for the given array of ratings, if a setting for its title is set. 
+     * Searches for the given array of ratings, if a setting for its title is set.
      * If so, it returns the title with the ratings value as id.
      * If not, it returns the ratings value in both id and value of the array entry.
      * @param array $ratings
      * @return array of rating titles
      */
-    public function translate_ratings_to_titles(array $ratings){
+    public function translate_ratings_to_titles(array $ratings) {
         $result = array();
         foreach ($ratings as $id => $rating){
-           $result[$rating] = $this->translate_rating_to_titles($rating);
+            $result[$rating] = $this->translate_rating_to_titles($rating);
         }
         return $result;
     }
-    
+
     /**
      * Searches for the given rating, if a setting for its title is set.
      * If so, it returns the title .
@@ -133,36 +133,36 @@ abstract class strategytemplate {
      * @param $rating
      * @return rating title
      */
-    public function translate_rating_to_titles($rating){
-        $value = is_numeric($rating)?$this->get_settings_value($rating):null;
-        $result = is_null($value) ? $rating: $value;
+    public function translate_rating_to_titles($rating) {
+        $value = is_numeric($rating) ? $this->get_settings_value($rating) : null;
+        $result = is_null($value) ? $rating : $value;
         return $result;
     }
-    
+
     /**
      * Validates the current settings for requried fields or value restrictions
-     * @return array of validation errors. Keys are the field identifiers and values 
+     * @return array of validation errors. Keys are the field identifiers and values
      * are the error messages, which should be displayed.
      */
-    public function validate_settings(){
+    public function validate_settings() {
         $validation_info = $this->getValidationInfo();
         $errors = array();
         foreach ($validation_info as $key => $info){
-            if (isset($info[0]) && $info[0]===true){
-                if(array_key_exists($key, $this->_strategy_settings) && 
+            if (isset($info[0]) && $info[0] === true){
+                if(array_key_exists($key, $this->_strategy_settings) &&
                         (!isset($this->_strategy_settings[$key]) || $this->_strategy_settings[$key] === "")) {
                     $errors[$key] = get_string('err_required', ratingallocate_MOD_NAME);
                     break;
                 }
             }
             if (isset($info[1])){
-                if(array_key_exists($key, $this->_strategy_settings) && $this->_strategy_settings[$key]<$info[1]){
+                if(array_key_exists($key, $this->_strategy_settings) && $this->_strategy_settings[$key] < $info[1]){
                     $errors[$key] = get_string('err_minimum', ratingallocate_MOD_NAME,$info[1]);
                     break;
                 }
             }
             if (isset($info[2])){
-                if(array_key_exists($key, $this->_strategy_settings) && $this->_strategy_settings[$key]>$info[1]){
+                if(array_key_exists($key, $this->_strategy_settings) && $this->_strategy_settings[$key] > $info[1]){
                     $errors[$key] = get_string('err_maximum', ratingallocate_MOD_NAME,$info[2]);
                     break;
                 }
@@ -170,7 +170,7 @@ abstract class strategytemplate {
         }
         return $errors;
     }
-    
+
     /**
      * @return array of arrays:     key - identifier of setting_dependenc
      *                              value[0] - is setting required
@@ -191,7 +191,7 @@ abstract class ratingallocate_strategyform extends \moodleform  {
     protected $ratingallocate;
 
     private $strategyoptions;
-    
+
     private $strategy;
 
     /**
@@ -201,7 +201,7 @@ abstract class ratingallocate_strategyform extends \moodleform  {
      */
     public function __construct($url, \ratingallocate $ratingallocate) {
         $this->ratingallocate = $ratingallocate;
-        //load strategy options
+        // load strategy options
         $allstrategyoptions = json_decode($this->ratingallocate->ratingallocate->setting, true);
         $strategyid = $ratingallocate->ratingallocate->strategy;
         if(array_key_exists($strategyid, $allstrategyoptions)) {
@@ -209,20 +209,20 @@ abstract class ratingallocate_strategyform extends \moodleform  {
         } else {
             $this->strategyoptions = array();
         }
-        $this->strategy=$this->construct_strategy($this->strategyoptions);
+        $this->strategy = $this->construct_strategy($this->strategyoptions);
         parent::__construct($url);
     }
-    
+
     /**
      * This method creates an instance of the strategy class for the form
      * @return \strategytemplate
      */
     protected abstract function construct_strategy($strategyoptions);
-    
+
     /**
      * @return \strategytemplate Returns the underlying strategy object.
      */
-    protected function get_strategy(){
+    protected function get_strategy() {
         return $this->strategy;
     }
 

--- a/strategy/strategy_template_options.php
+++ b/strategy/strategy_template_options.php
@@ -37,6 +37,20 @@ abstract class strategytemplate_options extends \strategytemplate {
      * @return array: value_of_option => title_of_option
      */
     public abstract function get_choiceoptions();
+
+    /**
+     * Returns the strategy option array, which can be included within the child option classes.
+     * @return array
+     */
+    protected function get_default_strategy_option() {
+        return ['default' => array(
+            'select',
+            get_string('strategy_settings_default', ratingallocate_MOD_NAME),
+            null,
+            $this->get_choiceoptions(),
+            'strategy_settings_default'
+        )];
+    }
 }
 
 /**
@@ -92,12 +106,12 @@ abstract class ratingallocate_options_strategyform extends \ratingallocate_strat
             // Furthermore, use explanation as title/label of group.
             $mform->addGroup($radioarray, 'radioarr_' . $data->choiceid, $data->explanation, null, false);
 
-            $maxrating = max(array_keys($choiceoptions));
+            $defaultrating = $this->get_strategysetting('default');
             // Try to restore previous ratings.
-            if (is_numeric($data->rating) && $data->rating >= 0 && $data->rating <= $maxrating) {
+            if (is_numeric($data->rating) && $data->rating >= 0 && $data->rating <= $defaultrating) {
                 $mform->setDefault($ratingelem, $data->rating);
             } else {
-                $mform->setDefault($ratingelem, $maxrating);
+                $mform->setDefault($ratingelem, $defaultrating);
             }
             // $mform->setType($ratingelem, PARAM_INT);
         }

--- a/strategy/strategy_template_options.php
+++ b/strategy/strategy_template_options.php
@@ -107,6 +107,7 @@ abstract class ratingallocate_options_strategyform extends \ratingallocate_strat
             $mform->addGroup($radioarray, 'radioarr_' . $data->choiceid, $data->explanation, null, false);
 
             $defaultrating = $this->get_strategysetting('default');
+            $defaultrating = $defaultrating == null ? max(array_keys($choiceoptions)) : $defaultrating;
             // Try to restore previous ratings.
             if (is_numeric($data->rating) && $data->rating >= 0 && $data->rating <= $defaultrating) {
                 $mform->setDefault($ratingelem, $data->rating);

--- a/strategy/strategy_template_options.php
+++ b/strategy/strategy_template_options.php
@@ -40,10 +40,10 @@ abstract class strategytemplate_options extends \strategytemplate {
 
     /**
      * Returns the strategy option array, which can be included within the child option classes.
-     * @param int default value, if not set.
+     * @param int $defaultvalue default value, if not set.
      * @return array
      */
-    protected function get_default_strategy_option(int $defaultvalue) {
+    protected function get_default_strategy_option($defaultvalue) {
         return ['default' => array(
             'select',
             get_string('strategy_settings_default', ratingallocate_MOD_NAME),

--- a/strategy/strategy_template_options.php
+++ b/strategy/strategy_template_options.php
@@ -40,13 +40,14 @@ abstract class strategytemplate_options extends \strategytemplate {
 
     /**
      * Returns the strategy option array, which can be included within the child option classes.
+     * @param int default value, if not set.
      * @return array
      */
-    protected function get_default_strategy_option() {
+    protected function get_default_strategy_option(int $defaultvalue) {
         return ['default' => array(
             'select',
             get_string('strategy_settings_default', ratingallocate_MOD_NAME),
-            null,
+            $defaultvalue,
             $this->get_choiceoptions(),
             'strategy_settings_default'
         )];

--- a/tests/behat/behat_mod_ratingallocate.php
+++ b/tests/behat/behat_mod_ratingallocate.php
@@ -332,6 +332,47 @@ class behat_mod_ratingallocate extends behat_base {
         $link->click();
     }
 
+    /**
+     * I should see the following rating form.
+     *
+     * @Then /^I should see the following rating form:$/
+     *
+     * @param TableNode $ratingdata exoected in the rating form
+     */
+    public function i_should_see_the_followin_rating_form(TableNode $ratingdata) {
+        $ratingdatehash = $ratingdata->getRowsHash();
+        // The action depends on the field type.
+        foreach ($ratingdatehash as $choice => $value) {
+            $fieldxpath = "//a[normalize-space(.)=\"$choice\"]/ancestor::fieldset/descendant::input[@type='radio' and @checked and @value=$value]";
+            try {
+                $this->find('xpath', $fieldxpath);
+            } catch (ElementNotFoundException $e) {
+                throw new ExpectationException('"' . $choice . '" choice was not rated ' . $value, $this->getSession());
+            }
+        }
+    }
+
+    /**
+     * I should see the following rating form.
+     *
+     * @When /^I set the rating form to the following values:$/
+     *
+     * @param TableNode $ratingdata values to be set in the rating form
+     */
+    public function i_set_the_rating_form_to_the_following_values(TableNode $ratingdata) {
+        $ratingdatehash = $ratingdata->getRowsHash();
+        // The action depends on the field type.
+        foreach ($ratingdatehash as $choice => $value) {
+            $fieldxpath = "//a[normalize-space(.)=\"$choice\"]/ancestor::fieldset/descendant::input[@type='radio' and @value=$value]";
+            try {
+                $option = $this->find('xpath', $fieldxpath);
+                $option->click();
+            } catch (ElementNotFoundException $e) {
+                throw new ExpectationException('Option "'.$value.'"  was not found for choice "' . $choice . '".' . $value, $this->getSession());
+            }
+        }
+    }
+
 }
 
 

--- a/tests/behat/defaultratings.feature
+++ b/tests/behat/defaultratings.feature
@@ -1,0 +1,94 @@
+@mod @mod_ratingallocate @javascript
+Feature: When a student starts a rating the default values of all choices
+  are set according to the instance settings.
+
+  Background:
+    Given the following "courses" exist:
+      | fullname | shortname | category | groupmode |
+      | Course 1 | C1        | 0        | 1         |
+    And the following "users" exist:
+      | username | firstname | lastname | email |
+      | teacher1 | Teacher | 1 | teacher1@example.com |
+      | student1 | Student | 1 | student1@example.com |
+    And the following "course enrolments" exist:
+      | user | course | role |
+      | teacher1 | C1 | editingteacher |
+      | student1 | C1 | student |
+    And the following "activities" exist:
+      | activity | course | idnumber | name |
+      | ratingallocate   | C1     | ra1  | My Fair Allocation |
+    And I log in as "teacher1"
+    And I am on "Course 1" course homepage with editing mode on
+    And I follow "My Fair Allocation"
+    And I press "Edit Choices"
+    And I add a new choice with the values:
+      | title       | My first choice |
+      | explanation | Test 1          |
+      | maxsize     |	2	    	  |
+    And I add a new choice with the values:
+      | title       | My second choice |
+      | explanation | Test 1          |
+      | maxsize     |	2	    	  |
+
+  @javascript
+  Scenario: The default rating is the max rating
+    And I navigate to "Edit settings" node in "Fair Allocation administration"
+    And I select "strategy_lickert" from the "strategy" singleselect
+    And I press "id_submitbutton"
+    And I log out
+    When I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I follow "My Fair Allocation"
+    And I press "Edit Rating"
+    Then I should see the following rating form:
+      | My first choice | 4 |
+      | My second choice | 4 |
+
+  @javascript
+  Scenario: The default rating should be changeable to a medium rating
+    And I navigate to "Edit settings" node in "Fair Allocation administration"
+    And I select "strategy_lickert" from the "strategy" singleselect
+    And I select "3" from the "strategyopt[strategy_lickert][default]" singleselect
+    And I press "id_submitbutton"
+    And I log out
+    When I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I follow "My Fair Allocation"
+    And I press "Edit Rating"
+    Then I should see the following rating form:
+      | My first choice | 3 |
+      | My second choice | 3 |
+
+  @javascript
+  Scenario: The default rating should be changeable to the lowest rating
+    And I navigate to "Edit settings" node in "Fair Allocation administration"
+    And I select "strategy_lickert" from the "strategy" singleselect
+    And I select "0" from the "strategyopt[strategy_lickert][default]" singleselect
+    And I press "id_submitbutton"
+    And I log out
+    When I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I follow "My Fair Allocation"
+    And I press "Edit Rating"
+    Then I should see the following rating form:
+      | My first choice | 0 |
+      | My second choice | 0 |
+
+  @javascript
+  Scenario: The default rating is the max rating
+    And I navigate to "Edit settings" node in "Fair Allocation administration"
+    And I select "strategy_lickert" from the "strategy" singleselect
+    And I press "id_submitbutton"
+    And I log out
+    When I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I follow "My Fair Allocation"
+    And I press "Edit Rating"
+    And I set the rating form to the following values:
+      | My first choice | 2 |
+      | My second choice | 3 |
+    And I press "Save changes"
+    And I press "Edit Rating"
+    Then I should see the following rating form:
+      | My first choice | 2 |
+      | My second choice | 3 |


### PR DESCRIPTION
The teacher now has the possibility to set a default option, which is used for the first creation of the rating form presented to students.