### PR TITLE
Added a report for allocations only

### DIFF
--- a/classes/allocations_table.php
+++ b/classes/allocations_table.php
@@ -121,9 +121,9 @@ class allocations_table extends \table_sql {
             $users = $this->ratingallocate->get_raters_in_course();
 
             foreach ($allocations as $allocation) {
-                if (array_key_exists($allocation->choiceid, $data)) {
-                    $userid = $allocation->userid;
-                    if (array_key_exists($userid, $users)) {
+                $userid = $allocation->userid;
+                if (array_key_exists($userid, $users)) {
+                    if (array_key_exists($allocation->choiceid, $data)) {
                         if (object_property_exists($data[$allocation->choiceid], 'users')) {
                             $data[$allocation->choiceid]->users .= ', ';
                         } else {
@@ -131,8 +131,8 @@ class allocations_table extends \table_sql {
                         }
 
                         $data[$allocation->choiceid]->users .= $this->get_user_link($users[$userid]);
-                        unset($userwithrating[$userid]);
                     }
+                    unset($userwithrating[$userid]);
                 }
             }
 

--- a/classes/allocations_table.php
+++ b/classes/allocations_table.php
@@ -1,0 +1,193 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Table displaying the allocated users for each choice.
+ * @package    mod_ratingallocate
+ * @copyright  2018 T Reischmann
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace mod_ratingallocate;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->libdir.'/tablelib.php');
+
+class allocations_table extends \table_sql {
+
+    const CHOICE_COL = 'choice_';
+    const EXPORT_CHOICE_ALLOC_SUFFIX = 'alloc';
+    const EXPORT_CHOICE_TEXT_SUFFIX = 'text';
+
+    private $choicenames = array();
+    private $choicemax = array();
+    private $choicesum = array();
+
+    private $titles;
+
+    private $shownames;
+
+    /**
+     * @var bool if true the cells are rendered as radio buttons
+     */
+    private $writeable;
+
+    /**
+     * @var \ratingallocate
+     */
+    private $ratingallocate;
+
+    /**
+     * @var \mod_ratingallocate_renderer
+     */
+    private $renderer;
+
+    /**
+     * allocations_table constructor.
+     * @param \mod_ratingallocate_renderer $renderer responsible renderers
+     * @param $titles
+     * @param \ratingallocate $ratingallocate
+     */
+    public function __construct(\mod_ratingallocate_renderer $renderer, $titles, $ratingallocate) {
+        parent::__construct('mod_ratingallocate_allocation_table');
+        global $PAGE;
+        $url = $PAGE->url;
+        $url->params(array("action" => ACTION_SHOW_ALLOCATION_TABLE));
+        $PAGE->set_url($url);
+        $this->renderer = $renderer;
+        $this->titles   = $titles;
+        $this->ratingallocate = $ratingallocate;
+        if (has_capability('mod/ratingallocate:export_ratings', $ratingallocate->get_context())) {
+            $download = optional_param('download', '', PARAM_ALPHA);
+            $this->is_downloading($download, $ratingallocate->ratingallocate->name, 'Testsheet');
+        }
+    }
+
+    /**
+     * Setup the table headers and columns
+     */
+    public function setup_table() {
+
+        if (empty($this->baseurl)) {
+            global $PAGE;
+            $this->baseurl = $PAGE->url;
+        }
+
+        if ($this->is_downloading()) {
+            $columns[] = 'id';
+            $headers[] = 'ID';
+            $columns[] = 'username';
+            $headers[] = get_string('username');
+            $columns[] = 'firstname';
+            $headers[] = get_string('firstname');
+            $columns[] = 'lastname';
+            $headers[] = get_string('lastname');
+            if (has_capability('moodle/course:useremail', $this->ratingallocate->get_context())) {
+                $columns[] = 'email';
+                $headers[] = get_string('email');
+            }
+        }
+        $columns[] = 'choice';
+        $headers[] = get_string('choice', ratingallocate_MOD_NAME);
+
+        if (!$this->is_downloading()) {
+            $columns[] = 'users';
+            $headers[] = get_string('allocations_table_users', ratingallocate_MOD_NAME);
+        }
+
+        $this->define_columns($columns);
+        $this->define_headers($headers);
+
+        // Perform the rest of the flextable setup.
+        parent::setup();
+
+        $this->init_sql();
+    }
+
+    /**
+     * Should be called after setup_choices
+     *
+     * @param array $ratings     an array of ratings -- the data for this table
+     * @param array $allocations an array of allocations
+     * @param bool $writeable if true the cells are rendered as radio buttons
+     */
+    public function build_table_by_sql($ratings, $allocations, $writeable = false) {
+
+        $this->writeable = $writeable;
+
+        $users = $this->rawdata;
+
+        // Group all ratings per user to match table structure.
+        $ratingsbyuser = array();
+        foreach ($ratings as $rating) {
+            if (empty($ratingsbyuser[$rating->userid])) {
+                $ratingsbyuser[$rating->userid] = array();
+            }
+            $ratingsbyuser[$rating->userid][$rating->choiceid] = $rating->rating;
+        }
+
+        // Group all memberships per user per choice.
+        $allocationsbyuser = array();
+        foreach ($allocations as $allocation) {
+            if (empty($allocationsbyuser[$allocation->userid])) {
+                $allocationsbyuser[$allocation->userid] = array();
+            }
+            $allocationsbyuser[$allocation->userid][$allocation->choiceid] = true;
+        }
+
+        // Add rating rows for each user.
+        foreach ($users as $user) {
+            $userratings        = isset($ratingsbyuser[$user->id]) ? $ratingsbyuser[$user->id] : array();
+            $userallocations    = isset($allocationsbyuser[$user->id]) ? $allocationsbyuser[$user->id] : array();
+            $this->add_user_ratings_row($user, $userratings, $userallocations);
+        }
+
+        $this->finish_output();
+    }
+
+
+    /**
+     * Will be called by $this->format_row when processing the 'choice' columns
+     *
+     * @param string $column
+     * @param object $row
+     *
+     * @return string rendered choice cell
+     */
+    public function other_cols($column, $row) {
+
+    }
+
+    /**
+     * Sets up the sql statement for querying the table data.
+     */
+    public function init_sql() {
+        $fields = "c.*";
+
+        $from = "{ratingallocate_choices} c";
+
+        $where = "ratingallocateid = :ratingallocateid";
+
+        $params = array();
+        $params['ratingallocateid'] = $this->ratingallocate->ratingallocate->id;
+
+        $this->set_sql($fields, $from, $where, $params);
+
+        $this->query_db(20);
+    }
+
+}

--- a/classes/allocations_table.php
+++ b/classes/allocations_table.php
@@ -137,7 +137,7 @@ class allocations_table extends \table_sql {
             }
 
             // If there are users, which rated but were not allocated, add them to a special row.
-            if (count($userwithrating) > 0) {
+            if (count($userwithrating) > 0 AND ($this->currpage + 1) * $this->pagesize >= $this->totalrows) {
                 $noallocation = new \stdClass();
                 $noallocation->choicetitle = get_string(
                     'allocations_table_noallocation',

--- a/classes/allocations_table.php
+++ b/classes/allocations_table.php
@@ -190,11 +190,12 @@ class allocations_table extends \table_sql {
 
             $from = "{ratingallocate_allocations} a JOIN {ratingallocate_choices} c ON a.choiceid = c.id JOIN {user} u ON a.userid = u.id";
         } else {
-            $fields = "distinct c.*, c.title as choicetitle";
+            $fields = "c.id, c.title as choicetitle";
 
-            $from = "{ratingallocate_allocations} a JOIN {ratingallocate_choices} c ON a.choiceid = c.id";
+            $from = "{ratingallocate_choices} c";
         }
-        $where = "a.ratingallocateid = :ratingallocateid";
+
+        $where = "c.ratingallocateid = :ratingallocateid";
 
         $params = array();
         $params['ratingallocateid'] = $this->ratingallocate->ratingallocate->id;

--- a/classes/event/ratings_and_allocation_table_viewed.php
+++ b/classes/event/ratings_and_allocation_table_viewed.php
@@ -1,0 +1,64 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+ 
+/**
+ * The mod_ratingallocate ratings_and_allocation_table_viewed event.
+ *
+ * @package    mod_ratingallocate
+ * @copyright  2014 Tobias Reischmann
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace mod_ratingallocate\event;
+defined('MOODLE_INTERNAL') || die();
+/**
+ * The mod_ratingallocate ratings_and_allocation_table_viewed event class.
+ *
+ * @since     Moodle 2.7
+ * @copyright 2014 Tobias Reischmann
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ **/
+class ratings_and_allocation_table_viewed extends \core\event\base {
+    
+    public static function create_simple($coursecontext, $ratingallocateid){
+        return self::create(array('context'=>$coursecontext,'objectid'=>$ratingallocateid));
+    }
+    
+    protected function init() {
+        $this->data['crud'] = 'r';
+        $this->data['edulevel'] = self::LEVEL_TEACHING;
+        $this->data['objecttable'] = 'ratingallocate';
+    }
+ 
+    public static function get_name() {
+        return get_string('log_ratings_and_allocation_table_viewed', 'mod_ratingallocate');
+    }
+ 
+    public function get_description() {
+        return get_string('log_ratings_and_allocation_table_viewed_description', 'mod_ratingallocate', array('userid' => $this->userid, 'ratingallocateid' => $this->objectid));
+    }
+ 
+    public function get_url() {
+        return new \moodle_url('/mod/ratingallocate/view.php', array('m' => $this->objectid));
+    }
+
+    public static function get_objectid_mapping() {
+        return array('db' => 'ratingallocate', 'restore' => 'ratingallocate');
+    }
+
+    public static function get_other_mapping() {
+        return false;
+    }
+}

--- a/classes/ratings_and_allocations_table.php
+++ b/classes/ratings_and_allocations_table.php
@@ -56,7 +56,7 @@ class ratings_and_allocations_table extends \table_sql {
     private $renderer;
 
     public function __construct(\mod_ratingallocate_renderer $renderer, $titles, $ratingallocate,
-                                $action = 'show_alloc_table', $uniqueid = 'mod_ratingallocate_table', $downloadable = true) {
+                                $action = ACTION_SHOW_RATINGS_AND_ALLOCATION_TABLE, $uniqueid = 'mod_ratingallocate_table', $downloadable = true) {
         parent::__construct($uniqueid);
         global $PAGE;
         $url = $PAGE->url;
@@ -197,7 +197,7 @@ class ratings_and_allocations_table extends \table_sql {
         }
 
         if (!$this->is_downloading()) {
-            $this->add_summary_row();
+            $this->add_summary_row();   
             $this->print_hidden_user_fields($users);
         }
 

--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -159,6 +159,8 @@ It is counting the allocations according to the rating the user has given to the
 <li>{$a->users} out of {$a->total} user(s) got a choice they rated with "{$a->rating}".</li>
 <li>{$a->unassigned} user(s) could not be allocated to a choice yet.</li>
 </ul>';
+$string['allocation_table_description'] = 'This statistic gives an overview over all allocations of this instance.</br>
+All users, which rated and were not allocated, are listed under \'No Allocation\'';
 $string['allocation_statistics_description_no_alloc'] = 'This statistic gives an impression of the overall satisfaction of the allocation.
 It is counting the allocations according to the rating the user has given to the respective choice.
 <ul>

--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -318,6 +318,9 @@ $string['log_ratingallocate_viewed_description'] =  'The user with id "{$a->user
 $string['log_allocation_table_viewed'] = 'Allocation table viewed';
 $string['log_allocation_table_viewed_description'] =  'The user with id "{$a->userid}" viewed the allocation table for the Fair Allocation with id "{$a->ratingallocateid}".';
 
+$string['log_ratings_and_allocation_table_viewed'] = 'Ratings and allocation table viewed';
+$string['log_ratings_and_allocation_table_viewed_description'] =  'The user with id "{$a->userid}" viewed the ratings and allocation table for the Fair Allocation with id "{$a->ratingallocateid}".';
+
 $string['log_allocation_statistics_viewed'] = 'Allocation statistics viewed';
 $string['log_allocation_statistics_viewed_description'] =  'The user with id "{$a->userid}" viewed the allocation statistics for the Fair Allocation with id "{$a->ratingallocateid}".';
 

--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -81,6 +81,10 @@ $string['ratings_table'] = 'Ratings and Allocations';
 $string['ratings_table_sum_allocations'] = 'Number of allocations / Maximum';
 $string['ratings_table_sum_allocations_value'] = '{$a->sum} / {$a->max}';
 $string['ratings_table_user'] = 'User';
+$string['allocations_table'] = 'Allocations Overview';
+$string['allocations_table_choice'] = 'Choice';
+$string['allocations_table_users'] = 'Users';
+$string['allocations_table_noallocation'] = 'No Allocation';
 $string['start_distribution_explanation'] = ' An algorithm will automatically try to fairly allocate the users according to their given ratings.';
 $string['distribution_table'] = 'Distribution Table';
 $string['download_problem_mps_format'] = 'Download Equation (mps/txt)';
@@ -145,7 +149,7 @@ $string['filter_show_alloc_necessary'] = 'Hide users with allocation';
 $string['update_filter'] = 'Update Filter';
 
 $string['show_table'] = 'Show Ratings and Allocations';
-
+$string['show_allocation_table'] = 'Show Allocations Overview';
 $string['allocation_statistics'] = 'Allocation Statistics';
 $string['show_allocation_statistics'] = 'Show Allocation Statistics';
 $string['allocation_statistics_description'] = 'This statistic gives an impression of the overall satisfaction of the allocation.

--- a/locallib.php
+++ b/locallib.php
@@ -784,6 +784,7 @@ class ratingallocate {
 
             case ACTION_SHOW_RATINGS_AND_ALLOCATION_TABLE:
                 $output .= $this->process_action_show_ratings_and_alloc_table();
+                $this->showinfo = false;
                 break;
 
             case ACTION_SHOW_ALLOCATION_TABLE:
@@ -793,6 +794,7 @@ class ratingallocate {
 
             case ACTION_SHOW_STATISTICS:
                 $output .= $this->process_action_show_statistics();
+                $this->showinfo = false;
                 break;
 
             default:

--- a/locallib.php
+++ b/locallib.php
@@ -788,6 +788,7 @@ class ratingallocate {
 
             case ACTION_SHOW_ALLOCATION_TABLE:
                 $output .= $this->process_action_show_allocation_table();
+                $this->showinfo = false;
                 break;
 
             case ACTION_SHOW_STATISTICS:

--- a/renderer.php
+++ b/renderer.php
@@ -391,7 +391,7 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
         $tableurl = new moodle_url($PAGE->url, array('action' => ACTION_SHOW_ALLOCATION_TABLE));
 
         // Button with link to display information about the allocations and ratings
-        $output .= $this->single_button($tableurl, get_string('show_distribution_table', ratingallocate_MOD_NAME));
+        $output .= $this->single_button($tableurl, get_string('show_allocation_table', ratingallocate_MOD_NAME));
 
         $tableurl = new moodle_url($PAGE->url, array('action' => ACTION_SHOW_STATISTICS));
 
@@ -615,22 +615,19 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
      *
      * @return string html code representing ratings table
      */
-    public function allocation_table_for_ratingallocate($choices, $ratings, $users, $memberships, $ratingallocate) {
-
-        // get rating titles
-        $titles = $this->get_options_titles(array_map(function($rating) {return $rating->rating;},$ratings), $ratingallocate);
+    public function allocation_table_for_ratingallocate($ratingallocate) {
 
         // Create and set up the flextable for ratings and allocations.
-        $table = new mod_ratingallocate\allocations_table($this, $titles, $ratingallocate);
-        $table->setup_table($choices, false, false);
+        $table = new mod_ratingallocate\allocations_table($ratingallocate);
+        $table->setup_table();
 
         // The rest must be done through output buffering due to the way flextable works.
         ob_start();
-        $table->build_table_by_sql($ratings, $memberships);
+        $table->build_table_by_sql();
         $tableoutput = ob_get_contents();
         ob_end_clean();
 
-        $output = $this->heading(get_string('ratings_table', ratingallocate_MOD_NAME), 2);
+        $output = $this->heading(get_string('allocations_table', ratingallocate_MOD_NAME), 2);
         $output .= $this->box_start();
         $output .= $this->box($tableoutput);
         $output .= $this->box_end();

--- a/renderer.php
+++ b/renderer.php
@@ -383,10 +383,15 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
         $output .= $this->heading(get_string('reports_group', ratingallocate_MOD_NAME), 2);
         $output .= $this->box_start();
 
-        $tableurl = new moodle_url($PAGE->url, array('action' => ACTION_SHOW_ALLOC_TABLE));
+        $tableurl = new moodle_url($PAGE->url, array('action' => ACTION_SHOW_RATINGS_AND_ALLOCATION_TABLE));
 
         // Button with link to display information about the allocations and ratings
         $output .= $this->single_button($tableurl, get_string('show_table', ratingallocate_MOD_NAME));
+
+        $tableurl = new moodle_url($PAGE->url, array('action' => ACTION_SHOW_ALLOCATION_TABLE));
+
+        // Button with link to display information about the allocations and ratings
+        $output .= $this->single_button($tableurl, get_string('show_distribution_table', ratingallocate_MOD_NAME));
 
         $tableurl = new moodle_url($PAGE->url, array('action' => ACTION_SHOW_STATISTICS));
 
@@ -533,7 +538,7 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
      *
      * @return string html code representing the distribution table
      */
-    public function distribution_table_for_ratingallocate(ratingallocate $ratingallocate) {
+    public function statistics_table_for_ratingallocate(ratingallocate $ratingallocate) {
         // Count the number of allocations with a specific rating
         $distributiondata = array();
 
@@ -600,6 +605,34 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
                     'unassigned' => count($usersinchoice) - count($memberships))));
             $output .= html_writer::table($allocationtable);
         }
+        $output .= $this->box_end();
+
+        return $output;
+    }
+
+    /**
+     * Shows table containing information about the allocation of users.
+     *
+     * @return string html code representing ratings table
+     */
+    public function allocation_table_for_ratingallocate($choices, $ratings, $users, $memberships, $ratingallocate) {
+
+        // get rating titles
+        $titles = $this->get_options_titles(array_map(function($rating) {return $rating->rating;},$ratings), $ratingallocate);
+
+        // Create and set up the flextable for ratings and allocations.
+        $table = new mod_ratingallocate\allocations_table($this, $titles, $ratingallocate);
+        $table->setup_table($choices, false, false);
+
+        // The rest must be done through output buffering due to the way flextable works.
+        ob_start();
+        $table->build_table_by_sql($ratings, $memberships);
+        $tableoutput = ob_get_contents();
+        ob_end_clean();
+
+        $output = $this->heading(get_string('ratings_table', ratingallocate_MOD_NAME), 2);
+        $output .= $this->box_start();
+        $output .= $this->box($tableoutput);
         $output .= $this->box_end();
 
         return $output;

--- a/renderer.php
+++ b/renderer.php
@@ -628,6 +628,8 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
         ob_end_clean();
 
         $output = $this->heading(get_string('allocations_table', ratingallocate_MOD_NAME), 2);
+        $output .= $this->format_text(get_string('allocation_table_description',
+            ratingallocate_MOD_NAME));
         $output .= $this->box_start();
         $output .= $this->box($tableoutput);
         $output .= $this->box_end();


### PR DESCRIPTION
The report shows the allocations in a similar fashion as the groups overview within a course. It is also possible to export the results with one line per user. This should fix the duplicates #154 and #143 