### PR TITLE
Fix give-points strategy

### DIFF
--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -273,7 +273,7 @@ $string['strategy_points_explain_distribute_points'] = 'Give points to each choi
 $string['strategy_points_explain_max_zero'] = 'You may only assign 0 points to at most {$a} choice(s).';
 $string['strategy_points_incorrect_totalpoints'] = 'Incorrect total number of points. The sum of all points has to be {$a}.';
 $string['strategy_points_setting_totalpoints'] = 'Total number of points the user can assign';
-$string['strategy_points_max_count_zero'] = 'You have to assign more than 0 points to at least {$a} choice(s).';
+$string['strategy_points_max_count_zero'] = 'You may give 0 points to at most {$a} choice(s).';
 $string['strategy_points_illegal_entry'] = 'The points that you assign to a choice must be between 0 and {$a}.';
 
 // Specific to Strategy05, Order

--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -274,6 +274,7 @@ $string['strategy_points_explain_max_zero'] = 'You may only assign 0 points to a
 $string['strategy_points_incorrect_totalpoints'] = 'Incorrect total number of points. The sum of all points has to be {$a}.';
 $string['strategy_points_setting_totalpoints'] = 'Total number of points the user can assign';
 $string['strategy_points_max_count_zero'] = 'You have to assign more than 0 points to at least {$a} choice(s).';
+$string['strategy_points_illegal_entry'] = 'The points that you assign to a choice must be between 0 and {$a}.';
 
 // Specific to Strategy05, Order
 $string['strategy_order_name'] = 'Rank Choices';

--- a/strategy/strategy04_points.php
+++ b/strategy/strategy04_points.php
@@ -151,8 +151,10 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
         $impossibles = 0;
         $ratings = $data ['data'];
         $currentpoints = 0;
-        foreach ($ratings as $rating) {
-            if ($rating ['rating'] == 0) {
+        foreach ($ratings as $cid => $rating) {
+            if ($rating['rating'] < 0 || $rating['rating'] > $totalpoints) {
+                $errors['data[' . $cid . '][rating]'] = get_string(strategy::STRATEGYID . '_illegal_entry', ratingallocate_MOD_NAME, $totalpoints);
+            } else if ($rating ['rating'] == 0) {
                 $impossibles ++;
             }
             $currentpoints += $rating['rating'];

--- a/tests/behat/behat_mod_ratingallocate.php
+++ b/tests/behat/behat_mod_ratingallocate.php
@@ -510,7 +510,7 @@ class behat_mod_ratingallocate extends behat_base {
     }
 
     /**
-     * I should see the following rating form.
+     * I set the rating form to the following values (only works for radio buttons).
      *
      * @When /^I set the rating form to the following values:$/
      *
@@ -526,6 +526,27 @@ class behat_mod_ratingallocate extends behat_base {
                 $option->click();
             } catch (ElementNotFoundException $e) {
                 throw new ExpectationException('Option "'.$value.'"  was not found for choice "' . $choice . '".' . $value, $this->getSession());
+            }
+        }
+    }
+
+    /**
+     * Enter points for choices
+     *
+     * @When /^I rate choices with the following points:$/
+     *
+     * @param TableNode $ratingdata values to be set in the rating form
+     */
+    public function i_rate_choices_with_the_following_points(TableNode $ratingdata) {
+        $ratingdatehash = $ratingdata->getRowsHash();
+        // The action depends on the field type.
+        foreach ($ratingdatehash as $choice => $value) {
+            $fieldxpath = "//legend[normalize-space(.)=\"$choice\"]/ancestor::fieldset/descendant::input[@type='text']";
+            try {
+                $option = $this->find('xpath', $fieldxpath);
+                $option->setValue($value);
+            } catch (ElementNotFoundException $e) {
+                throw new ExpectationException('Choice "' . $choice . '" was not found.', $this->getSession());
             }
         }
     }

--- a/tests/behat/validate_rating.feature
+++ b/tests/behat/validate_rating.feature
@@ -46,7 +46,7 @@ Feature: When a student attempts to rate choices it should be validated prior to
     And I am on "Course 1" course homepage
     And I follow "Validated Rating"
     And I press "Edit Rating"
-    And I set the rating form to the following values:
+    And I rate choices with the following points:
       | My first choice | -1 |
       | My second choice | 1 |
       | My third choice | 1 |
@@ -59,7 +59,7 @@ Feature: When a student attempts to rate choices it should be validated prior to
     And I am on "Course 1" course homepage
     And I follow "Validated Rating"
     And I press "Edit Rating"
-    And I set the rating form to the following values:
+    And I rate choices with the following points:
       | My first choice | 1 |
       | My second choice | 2 |
       | My third choice | 3 |
@@ -72,7 +72,7 @@ Feature: When a student attempts to rate choices it should be validated prior to
     And I am on "Course 1" course homepage
     And I follow "Validated Rating"
     And I press "Edit Rating"
-    And I set the rating form to the following values:
+    And I rate choices with the following points:
       | My first choice | 0 |
       | My second choice | 0 |
       | My third choice | 0 |

--- a/tests/behat/validate_rating.feature
+++ b/tests/behat/validate_rating.feature
@@ -1,0 +1,81 @@
+@mod @mod_ratingallocate
+Feature: When a student attempts to rate choices it should be validated prior to changing.
+
+  Background:
+    Given the following "courses" exist:
+      | fullname | shortname | category | groupmode |
+      | Course 1 | C1        | 0        | 1         |
+    And the following "users" exist:
+      | username | firstname | lastname | email |
+      | teacher1 | Teacher | 1 | teacher1@example.com |
+      | student1 | Student | 1 | student1@example.com |
+    And the following "course enrolments" exist:
+      | user | course | role |
+      | teacher1 | C1 | editingteacher |
+      | student1 | C1 | student |
+    And I log in as "teacher1"
+    And I am on "Course 1" course homepage with editing mode on
+    And I add a "Fair Allocation" to section "1" and I fill the form with:
+      | id_name | Validated Rating |
+      | strategy    | strategy_points |
+      | accesstimestart[day] | ##2 days ago##j## |
+      | accesstimestart[month] | ##2 days ago##n## |
+      | accesstimestart[year] | ##2 days ago##Y## |
+    And I follow "Validated Rating"
+    And I press "Edit Choices"
+    And I add a new choice with the values:
+      | title       | My first choice |
+      | explanation | Test 1          |
+      | maxsize     |	2	    	  |
+    And I add a new choice with the values:
+      | title       | My second choice |
+      | explanation | Test 2           |
+      | maxsize     |	2	    	   |
+    And I add a new choice with the values:
+      | title       | My third choice |
+      | explanation | Test 3  		  |
+      | maxsize     |	2	    	  |
+    And I add a new choice with the values:
+      | title       | My fourth choice |
+      | explanation | Test 4  		  |
+      | maxsize     |	2	    	  |
+    And I log out
+
+  Scenario: The user cannot enter values less than 0.
+    When I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I follow "Validated Rating"
+    And I press "Edit Rating"
+    And I set the rating form to the following values:
+      | My first choice | -1 |
+      | My second choice | 1 |
+      | My third choice | 1 |
+      | My fourth choice | 99 |
+    And I press "Save changes"
+    Then I should see "The points that you assign to a choice must be between 0 and 100."
+
+  Scenario: The values entered by the user must sum up to the (default) maximum.
+    When I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I follow "Validated Rating"
+    And I press "Edit Rating"
+    And I set the rating form to the following values:
+      | My first choice | 1 |
+      | My second choice | 2 |
+      | My third choice | 3 |
+      | My fourth choice | 4 |
+    And I press "Save changes"
+    Then I should see "Incorrect total number of points. The sum of all points has to be 100."
+
+  Scenario: The user may not rate more than a (default) number of choices with 0.
+    When I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I follow "Validated Rating"
+    And I press "Edit Rating"
+    And I set the rating form to the following values:
+      | My first choice | 0 |
+      | My second choice | 0 |
+      | My third choice | 0 |
+      | My fourth choice | 0 |
+    And I press "Save changes"
+    Then I should see "You have to assign more than 0 points to at least 3 choice(s)."

--- a/tests/behat/validate_rating.feature
+++ b/tests/behat/validate_rating.feature
@@ -21,6 +21,7 @@ Feature: When a student attempts to rate choices it should be validated prior to
       | accesstimestart[day] | ##2 days ago##j## |
       | accesstimestart[month] | ##2 days ago##n## |
       | accesstimestart[year] | ##2 days ago##Y## |
+      | strategyopt[strategy_points][maxzero] | 2 |
     And I follow "Validated Rating"
     And I press "Edit Choices"
     And I add a new choice with the values:
@@ -76,6 +77,6 @@ Feature: When a student attempts to rate choices it should be validated prior to
       | My first choice | 0 |
       | My second choice | 0 |
       | My third choice | 0 |
-      | My fourth choice | 0 |
+      | My fourth choice | 100 |
     And I press "Save changes"
-    Then I should see "You have to assign more than 0 points to at least 3 choice(s)."
+    Then I should see "You may give 0 points to at most 2 choice(s)."


### PR DESCRIPTION
Fixes a bug in the "Give Points" strategy that allowed creative inputs. In the process...

- Rephrased the `strategy_points_max_count_zero` language string as it pointed into the wrong direction,
- added a Behat step that simulates a user giving points, and
- added Behat tests to test existing and new functionality of the "Give Points" strategy.