### PR TITLE
Log module events on module level

### DIFF
--- a/classes/event/allocation_published.php
+++ b/classes/event/allocation_published.php
@@ -38,8 +38,8 @@ defined('MOODLE_INTERNAL') || die();
  **/
 class allocation_published extends \core\event\base {
     
-    public static function create_simple($coursecontext, $ratingallocateid){
-        return self::create(array('context'=>$coursecontext,'objectid'=>$ratingallocateid));
+    public static function create_simple($modulecontext, $ratingallocateid){
+        return self::create(array('context'=>$modulecontext,'objectid'=>$ratingallocateid));
     }
     
     protected function init() {

--- a/classes/event/allocation_statistics_viewed.php
+++ b/classes/event/allocation_statistics_viewed.php
@@ -32,8 +32,8 @@ defined('MOODLE_INTERNAL') || die();
  **/
 class allocation_statistics_viewed extends \core\event\base {
     
-    public static function create_simple($coursecontext, $ratingallocateid){
-        return self::create(array('context'=>$coursecontext,'objectid'=>$ratingallocateid));
+    public static function create_simple($modulecontext, $ratingallocateid){
+        return self::create(array('context'=>$modulecontext,'objectid'=>$ratingallocateid));
     }
     
     protected function init() {

--- a/classes/event/allocation_table_viewed.php
+++ b/classes/event/allocation_table_viewed.php
@@ -32,8 +32,8 @@ defined('MOODLE_INTERNAL') || die();
  **/
 class allocation_table_viewed extends \core\event\base {
     
-    public static function create_simple($coursecontext, $ratingallocateid){
-        return self::create(array('context'=>$coursecontext,'objectid'=>$ratingallocateid));
+    public static function create_simple($modulecontext, $ratingallocateid){
+        return self::create(array('context'=>$modulecontext,'objectid'=>$ratingallocateid));
     }
     
     protected function init() {

--- a/classes/event/distribution_triggered.php
+++ b/classes/event/distribution_triggered.php
@@ -39,9 +39,9 @@ defined('MOODLE_INTERNAL') || die();
  **/
 class distribution_triggered extends \core\event\base {
     
-    public static function create_simple($coursecontext, $ratingallocateid, $time_needed){
+    public static function create_simple($modulecontext, $ratingallocateid, $time_needed){
         $time_needed_json_valid = json_decode(json_encode($time_needed),true);
-        return self::create(array('context' => $coursecontext, 'objectid' => $ratingallocateid,
+        return self::create(array('context' => $modulecontext, 'objectid' => $ratingallocateid,
                         'other' => array('time_needed'=>$time_needed_json_valid)));
     }
     protected function init() {

--- a/classes/event/manual_allocation_saved.php
+++ b/classes/event/manual_allocation_saved.php
@@ -38,8 +38,8 @@ defined('MOODLE_INTERNAL') || die();
  **/
 class manual_allocation_saved extends \core\event\base {
     
-    public static function create_simple($coursecontext, $ratingallocateid){
-        return self::create(array('context' => $coursecontext, 'objectid' => $ratingallocateid));
+    public static function create_simple($modulecontext, $ratingallocateid){
+        return self::create(array('context' => $modulecontext, 'objectid' => $ratingallocateid));
     }
     protected function init() {
         $this->data['crud'] = 'u';

--- a/classes/event/rating_deleted.php
+++ b/classes/event/rating_deleted.php
@@ -31,8 +31,8 @@ defined('MOODLE_INTERNAL') || die();
  **/
 class rating_deleted extends \core\event\base {
 
-    public static function create_simple($coursecontext, $ratingallocateid) {
-        return self::create(array('context' => $coursecontext, 'objectid' => $ratingallocateid));
+    public static function create_simple($modulecontext, $ratingallocateid) {
+        return self::create(array('context' => $modulecontext, 'objectid' => $ratingallocateid));
     }
     protected function init() {
         $this->data['crud'] = 'd';

--- a/classes/event/rating_saved.php
+++ b/classes/event/rating_saved.php
@@ -38,11 +38,11 @@ defined('MOODLE_INTERNAL') || die();
  **/
 class rating_saved extends \core\event\base {
     
-    public static function create_simple($coursecontext, $ratingallocateid, $rating){
+    public static function create_simple($modulecontext, $ratingallocateid, $rating){
         // the values of other need to be encoded since the base checks for equality of a decoded encoded other instance with the original.
         // this is not given for nested arrays
         $rating_json_valid = json_decode(json_encode($rating),true);
-        return self::create(array('context' => $coursecontext, 'objectid' => $ratingallocateid, 'other' => array('ratings'=>$rating_json_valid)));
+        return self::create(array('context' => $modulecontext, 'objectid' => $ratingallocateid, 'other' => array('ratings'=>$rating_json_valid)));
     }
     protected function init() {
         $this->data['crud'] = 'u';

--- a/classes/event/rating_viewed.php
+++ b/classes/event/rating_viewed.php
@@ -32,8 +32,8 @@ defined('MOODLE_INTERNAL') || die();
  **/
 class rating_viewed extends \core\event\base {
     
-    public static function create_simple($coursecontext, $ratingallocateid){
-        return self::create(array('context'=>$coursecontext,'objectid'=>$ratingallocateid));
+    public static function create_simple($modulecontext, $ratingallocateid){
+        return self::create(array('context'=>$modulecontext,'objectid'=>$ratingallocateid));
     }
     
     protected function init() {

--- a/classes/event/ratingallocate_viewed.php
+++ b/classes/event/ratingallocate_viewed.php
@@ -32,8 +32,8 @@ defined('MOODLE_INTERNAL') || die();
  **/
 class ratingallocate_viewed extends \core\event\base {
     
-    public static function create_simple($coursecontext, $ratingallocateid){
-        return self::create(array('context'=>$coursecontext,'objectid'=>$ratingallocateid));
+    public static function create_simple($modulecontext, $ratingallocateid){
+        return self::create(array('context'=>$modulecontext,'objectid'=>$ratingallocateid));
     }
     
     protected function init() {

--- a/classes/event/ratings_and_allocation_table_viewed.php
+++ b/classes/event/ratings_and_allocation_table_viewed.php
@@ -32,8 +32,8 @@ defined('MOODLE_INTERNAL') || die();
  **/
 class ratings_and_allocation_table_viewed extends \core\event\base {
     
-    public static function create_simple($coursecontext, $ratingallocateid){
-        return self::create(array('context'=>$coursecontext,'objectid'=>$ratingallocateid));
+    public static function create_simple($modulecontext, $ratingallocateid){
+        return self::create(array('context'=>$modulecontext,'objectid'=>$ratingallocateid));
     }
     
     protected function init() {

--- a/locallib.php
+++ b/locallib.php
@@ -578,7 +578,7 @@ class ratingallocate {
                 array('id' => $this->coursemodule->id)), get_string('back'), 'get');
             // Logging.
             $event = \mod_ratingallocate\event\allocation_statistics_viewed::create_simple(
-                context_course::instance($this->course->id), $this->ratingallocateid);
+                context_module::instance($this->coursemodule->id), $this->ratingallocateid);
             $event->trigger();
         }
         return $output;

--- a/locallib.php
+++ b/locallib.php
@@ -945,7 +945,7 @@ class ratingallocate {
 
         // Logging.
         $event = \mod_ratingallocate\event\allocation_published::create_simple(
-            context_course::instance($this->course->id), $this->ratingallocateid);
+            context_module::instance($this->coursemodule->id), $this->ratingallocateid);
         $event->trigger();
     }
 

--- a/locallib.php
+++ b/locallib.php
@@ -649,7 +649,7 @@ class ratingallocate {
 
         // Logging.
         $event = \mod_ratingallocate\event\ratingallocate_viewed::create_simple(
-                context_course::instance($this->course->id), $this->ratingallocateid);
+                context_module::instance($this->coursemodule->id), $this->ratingallocateid);
         $event->trigger();
 
         return $output;

--- a/locallib.php
+++ b/locallib.php
@@ -225,7 +225,7 @@ class ratingallocate {
 
                 // Logging.
                 $event = \mod_ratingallocate\event\distribution_triggered::create_simple(
-                    context_course::instance($this->course->id), $this->ratingallocateid, $timeneeded);
+                    context_module::instance($this->coursemodule->id), $this->ratingallocateid, $timeneeded);
                 $event->trigger();
 
                 redirect(new moodle_url($PAGE->url->out()),

--- a/locallib.php
+++ b/locallib.php
@@ -557,7 +557,7 @@ class ratingallocate {
                 array('id' => $this->coursemodule->id)), get_string('back'), 'get');
             // Logging.
             $event = \mod_ratingallocate\event\allocation_table_viewed::create_simple(
-                context_course::instance($this->course->id), $this->ratingallocateid);
+                context_module::instance($this->coursemodule->id), $this->ratingallocateid);
             $event->trigger();
         }
         return $output;

--- a/locallib.php
+++ b/locallib.php
@@ -1302,7 +1302,7 @@ class ratingallocate {
             }
             // Logging.
             $event = \mod_ratingallocate\event\manual_allocation_saved::create_simple(
-                    context_course::instance($this->course->id), $this->ratingallocateid);
+                    context_module::instance($this->coursemodule->id), $this->ratingallocateid);
             $event->trigger();
 
             $transaction->allow_commit();

--- a/locallib.php
+++ b/locallib.php
@@ -279,7 +279,7 @@ class ratingallocate {
                 $output .= $renderer->render_ratingallocate_strategyform($mform);
                 // Logging.
                 $event = \mod_ratingallocate\event\rating_viewed::create_simple(
-                    context_course::instance($this->course->id), $this->ratingallocateid);
+                    context_module::instance($this->coursemodule->id), $this->ratingallocateid);
                 $event->trigger();
             }
         }
@@ -1173,7 +1173,7 @@ class ratingallocate {
 
             // Logging.
             $event = \mod_ratingallocate\event\rating_deleted::create_simple(
-                context_course::instance($this->course->id), $this->ratingallocateid);
+                context_module::instance($this->coursemodule->id), $this->ratingallocateid);
             $event->trigger();
         } catch (Exception $e) {
             $transaction->rollback($e);
@@ -1230,7 +1230,7 @@ class ratingallocate {
             $transaction->allow_commit();
             // Logging.
             $event = \mod_ratingallocate\event\rating_saved::create_simple(
-                    context_course::instance($this->course->id), $this->ratingallocateid, $loggingdata);
+                    context_module::instance($this->coursemodule->id), $this->ratingallocateid, $loggingdata);
             $event->trigger();
         } catch (Exception $e) {
             $transaction->rollback($e);

--- a/locallib.php
+++ b/locallib.php
@@ -536,7 +536,7 @@ class ratingallocate {
 
             // Logging.
             $event = \mod_ratingallocate\event\ratings_and_allocation_table_viewed::create_simple(
-                context_course::instance($this->course->id), $this->ratingallocateid);
+                context_module::instance($this->coursemodule->id), $this->ratingallocateid);
             $event->trigger();
         }
         return $output;


### PR DESCRIPTION
Fixes #182 by adding the module's context to an event, replacing the course's context. This does not include the `index_viewed` event as that is the only event that is not module-specific.