### PR TITLE
Add a default sorting order: by lastname

### DIFF
--- a/classes/ratings_and_allocations_table.php
+++ b/classes/ratings_and_allocations_table.php
@@ -144,7 +144,7 @@ class ratings_and_allocations_table extends \table_sql {
         $this->define_headers($headers);
 
         // Set additional table settings.
-        $this->sortable(true);
+        $this->sortable(true, 'lastname');
         $this->set_attribute('class', 'ratingallocate_ratings_table');
 
         $this->initialbars(true);


### PR DESCRIPTION
There's a case that's not entirely clear to me, where a mixture of the standard sorting behaviour of moodle and table pagination result in a bug, where some students are displayed twice - on different pages - and other students are not shown at all.

Forcing a default sorting order resolves this problem. 

Sorting by lastname is probably in line with expectations, at least at our institution.