### PR TITLE
made user fields for downloads configurable

### DIFF
--- a/classes/allocations_table.php
+++ b/classes/allocations_table.php
@@ -63,15 +63,26 @@ class allocations_table extends \table_sql {
         }
 
         if ($this->is_downloading()) {
-            $columns[] = 'id';
-            $headers[] = 'ID';
-            $columns[] = 'username';
-            $headers[] = get_string('username');
+            global $CFG;
+            $additionalfields = explode(',', $CFG->ratingallocate_download_userfields);
+            if (in_array('id', $additionalfields)) {
+                $columns[] = 'id';
+                $headers[] = 'ID';
+            }
+            if (in_array('username', $additionalfields)) {
+                $columns[] = 'username';
+                $headers[] = get_string('username');
+            }
+            if (in_array('idnumber', $additionalfields)) {
+                $columns[] = 'idnumber';
+                $headers[] = get_string('idnumber');
+            }
             $columns[] = 'firstname';
             $headers[] = get_string('firstname');
             $columns[] = 'lastname';
             $headers[] = get_string('lastname');
-            if (has_capability('moodle/course:useremail', $this->ratingallocate->get_context())) {
+            if (in_array('email', $additionalfields) &&
+                    has_capability('moodle/course:useremail', $this->ratingallocate->get_context())) {
                 $columns[] = 'email';
                 $headers[] = get_string('email');
             }

--- a/classes/ratings_and_allocations_table.php
+++ b/classes/ratings_and_allocations_table.php
@@ -110,16 +110,27 @@ class ratings_and_allocations_table extends \table_sql {
 
         if ($this->shownames) {
             if ($this->is_downloading()) {
-                $columns[] = 'id';
-                $headers[] = 'ID';
-                $columns[] = 'username';
-                $headers[] = get_string('username');
+                global $CFG;
+                $additionalfields = explode(',', $CFG->ratingallocate_download_userfields);
+                if (in_array('id', $additionalfields)) {
+                    $columns[] = 'id';
+                    $headers[] = 'ID';
+                }
+                if (in_array('username', $additionalfields)) {
+                    $columns[] = 'username';
+                    $headers[] = get_string('username');
+                }
+                if (in_array('idnumber', $additionalfields)) {
+                    $columns[] = 'idnumber';
+                    $headers[] = get_string('idnumber');
+                }
                 $columns[] = 'firstname';
                 $headers[] = get_string('firstname');
                 $columns[] = 'lastname';
                 $headers[] = get_string('lastname');
                 global $COURSE;
-                if (has_capability('moodle/course:useremail', $this->ratingallocate->get_context())) {
+                if (in_array('email', $additionalfields) &&
+                        has_capability('moodle/course:useremail', $this->ratingallocate->get_context())) {
                     $columns[] = 'email';
                     $headers[] = get_string('email');
                 }

--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -46,6 +46,9 @@ $string['crontask'] = 'Automated allocation for Fair Allocation';
 $string['algorithmtimeout'] = 'Algorithm timeout';
 $string['configalgorithmtimeout'] = 'The time in seconds after which the algorithm is assumed to be stuck.
 The current run is terminated and marked as failed.';
+$string['downloaduserfields'] = 'Additional user fields for download';
+$string['configdownloaduserfields'] = 'When downloading a table with users in it, these fields may be shown in addition to the users\' first and last name.';
+$string['userid'] = 'User ID';
 // </editor-fold>
 // <editor-fold defaultstate="collapsed" desc="Rating Form for Users">
 $string['choicestatusheading'] = 'Status';

--- a/settings.php
+++ b/settings.php
@@ -11,4 +11,19 @@ defined('MOODLE_INTERNAL') || die;
 if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configtext('ratingallocate_algorithm_timeout', get_string('algorithmtimeout', 'ratingallocate'),
         get_string('configalgorithmtimeout', 'ratingallocate'), 600, PARAM_INT));
+
+    $settings->add(new admin_setting_configmulticheckbox('ratingallocate_download_userfields',
+        new lang_string('downloaduserfields', 'ratingallocate'),
+        new lang_string('configdownloaduserfields', 'ratingallocate'),
+        [
+            'id' => 1,
+            'username' => 1,
+            'email' => 1
+        ],
+        [
+            'id'          => new lang_string('userid', 'ratingallocate'),
+            'username'    => new lang_string('username'),
+            'idnumber'    => new lang_string('idnumber'),
+            'email'       => new lang_string('email'),
+        ]));
 }


### PR DESCRIPTION
This only concerns additional user fields, i.e. everything except the
name. First and last name are always exported (not configurable).