### PR TITLE
prevent sorting of users column

### DIFF
--- a/classes/allocations_table.php
+++ b/classes/allocations_table.php
@@ -94,6 +94,7 @@ class allocations_table extends \table_sql {
         if (!$this->is_downloading()) {
             $columns[] = 'users';
             $headers[] = get_string('allocations_table_users', ratingallocate_MOD_NAME);
+            $this->no_sorting('users');
         }
 
         $this->define_columns($columns);


### PR DESCRIPTION
When you try to sort the allocations table by the users column, an error occurs, because there is no column called 'users' in the database to sort by. Since sorting by multiple users didn't appear trivial to me, I decided to fix this by disabling sorting for the users column.