### PR TITLE
Don't show status summary on give rating page.

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -680,6 +680,7 @@ class ratingallocate {
 
             case ACTION_GIVE_RATING:
                 $output .= $this->process_action_give_rating();
+                $this->showinfo = false;
                 break;
 
             case ACTION_DELETE_RATING:


### PR DESCRIPTION
This takes up too much room on the rating page and mostly just repeats information already included in the page below.