### PR TITLE
Add support for file attachments on choices

### DIFF
--- a/form_modify_choice.php
+++ b/form_modify_choice.php
@@ -47,16 +47,18 @@ class modify_choice_form extends moodleform {
      * @param string $url
      * @param ratingallocate $ratingallocate
      * @param ratingallocate_choice $choice
+     * @param array $customdata
      */
     public function __construct($url, ratingallocate $ratingallocate,
-                                ratingallocate_choice $choice = null) {
+                                ratingallocate_choice $choice = null, $customdata = null) {
         $this->ratingallocate = $ratingallocate;
         if ($choice) {
             $this->choice = $choice;
         } else {
             $this->addnew = true;
         }
-        parent::__construct($url);
+
+        parent::__construct($url, $customdata);
     }
 
     /**
@@ -84,6 +86,13 @@ class modify_choice_form extends moodleform {
         $mform->addRule($elementname, get_string('err_required', 'form') , 'required', null, 'server');
         $mform->addRule($elementname, get_string('err_numeric', 'form') , 'numeric', null, 'server');
         $mform->addRule($elementname, get_string('err_positivnumber', 'ratingallocate') , 'regex', '/^[1-9][0-9]*|0/', 'server');
+
+        $elementname = 'attachments_filemanager';
+        $mform->addElement('filemanager', $elementname, get_string('uploadafile'), null, array(
+            'accepted_types' => '*',
+            'subdirs' => false,
+        ));
+        $this->set_data($this->_customdata['attachment_data']);
 
         $elementname = 'active';
         $mform->addElement('advcheckbox', $elementname, get_string('choice_active', ratingallocate_MOD_NAME),

--- a/lib.php
+++ b/lib.php
@@ -314,7 +314,7 @@ function ratingallocate_pluginfile($course, $cm, $context, $filearea, array $arg
     }
 
     $fs = get_file_storage();
-    $file = $fs->get_file($context->id, 'ratingallocate', $filearea, $itemid, $filepath, $filename);
+    $file = $fs->get_file($context->id, 'mod_ratingallocate', $filearea, $itemid, $filepath, $filename);
     if (!$file) {
         return false; // The file does not exist.
     }

--- a/lib.php
+++ b/lib.php
@@ -202,7 +202,7 @@ function ratingallocate_print_recent_activity($course, $viewfullnames, $timestar
  * @param int $groupid check for a particular group's activity only, defaults to 0 (all groups)
  * @return void adds items into $activities and increases $index
  */
-function ratingallocate_get_recent_mod_activity(&$activities, &$index, $timestart, $courseid, $cmid, 
+function ratingallocate_get_recent_mod_activity(&$activities, &$index, $timestart, $courseid, $cmid,
         $userid = 0, $groupid = 0) {
 }
 
@@ -290,12 +290,37 @@ function ratingallocate_pluginfile($course, $cm, $context, $filearea, array $arg
     global $DB, $CFG;
 
     if ($context->contextlevel != CONTEXT_MODULE) {
-        send_file_not_found();
+        return false;
+    }
+
+    if ($filearea !== 'choice_attachment') {
+        return false;
     }
 
     require_login($course, true, $cm);
 
-    send_file_not_found();
+    if (!has_capability('mod/ratingallocate:view', $context)) {
+        return false;
+    }
+
+    $itemid = array_shift($args);
+    $filename = array_pop($args);
+    if (!$args) {
+        // Empty path, use root.
+        $filepath = '/';
+    } else {
+        // Assemble filepath.
+        $filepath = '/'.implode('/', $args).'/';
+    }
+
+    $fs = get_file_storage();
+    $file = $fs->get_file($context->id, 'ratingallocate', $filearea, $itemid, $filepath, $filename);
+    if (!$file) {
+        return false; // The file does not exist.
+    }
+
+    // Send the file to the browser. Cache lifetime of 1 day, no filtering.
+    send_stored_file($file, 86400, 0, $forcedownload, $options);
 }
 
 // //////////////////////////////////////////////////////////////////////////////

--- a/locallib.php
+++ b/locallib.php
@@ -346,7 +346,7 @@ class ratingallocate {
     }
 
     private function process_action_edit_choice() {
-        global $DB, $PAGE, $USER;
+        global $DB, $PAGE;
 
         $output = '';
         if (has_capability('mod/ratingallocate:modify_choices', $this->context)) {

--- a/locallib.php
+++ b/locallib.php
@@ -35,6 +35,7 @@ require_once(dirname(__FILE__) . '/form_manual_allocation.php');
 require_once(dirname(__FILE__) . '/form_modify_choice.php');
 require_once(dirname(__FILE__) . '/renderable.php');
 require_once($CFG->dirroot.'/group/lib.php');
+require_once($CFG->dirroot . '/repository/lib.php');
 require_once(__DIR__.'/classes/algorithm_status.php');
 
 // Takes care of loading all the solvers.
@@ -345,7 +346,7 @@ class ratingallocate {
     }
 
     private function process_action_edit_choice() {
-        global $DB, $PAGE;
+        global $DB, $PAGE, $USER;
 
         $output = '';
         if (has_capability('mod/ratingallocate:modify_choices', $this->context)) {
@@ -358,21 +359,33 @@ class ratingallocate {
             } else {
                 $choice = null;
             }
+
+            $data = new stdClass();
+            $options = array('subdirs' => false, 'maxfiles' => -1, 'accepted_types' => '*', 'return_types' => FILE_INTERNAL);
+            file_prepare_standard_filemanager($data, 'attachments', $options, $this->context,
+                'ratingallocate', 'choice_attachment', $choiceid);
+
             $mform = new modify_choice_form(new moodle_url('/mod/ratingallocate/view.php',
-            array('id' => $this->coursemodule->id,
-                'ratingallocateid' => $this->ratingallocateid,
-                'action' => ACTION_EDIT_CHOICE)),
-            $this, $choice);
+                array('id' => $this->coursemodule->id,
+                    'ratingallocateid' => $this->ratingallocateid,
+                    'action' => ACTION_EDIT_CHOICE,
+                )),
+                $this, $choice, array('attachment_data' => $data));
 
             /* @var mod_ratingallocate_renderer */
             $renderer = $this->get_renderer();
 
             if ($mform->is_submitted() && $data = $mform->get_submitted_data()) {
+
                 if (!$mform->is_cancelled()) {
                     if ($mform->is_validated()) {
                         $this->save_modify_choice_form($data);
+
+                        $data = file_postupdate_standard_filemanager($data, 'attachments', $options, $this->context,
+                            'ratingallocate', 'choice_attachment', $data->choiceid);
                         $renderer->add_notification(get_string("choice_added_notification", ratingallocate_MOD_NAME),
-                            self::NOTIFY_SUCCESS);
+                        self::NOTIFY_SUCCESS);
+
                     } else {
                         $output .= $OUTPUT->heading(get_string('edit_choice', ratingallocate_MOD_NAME), 2);
                         $output .= $mform->to_html();
@@ -1332,7 +1345,8 @@ class ratingallocate {
                 $choice->id = $data->choiceid;
                 $DB->update_record(this_db\ratingallocate_choices::TABLE, $choice->dbrecord);
             } else {
-                $DB->insert_record(this_db\ratingallocate_choices::TABLE, $choice->dbrecord);
+                // Update choiceid for pass through to file attachments.
+                $data->choiceid = $DB->insert_record(this_db\ratingallocate_choices::TABLE, $choice->dbrecord);
             }
 
             // Logging.
@@ -1546,6 +1560,24 @@ class ratingallocate {
             }
         }
         return true;
+    }
+
+
+    /**
+     * @param int choiceid
+     * @return array of file objects.
+     */
+    public function get_file_attachments_for_choice($choiceid) {
+        $areafiles = get_file_storage()->get_area_files($this->context->id, "ratingallocate", "choice_attachment", $choiceid);
+        $files = array();
+        foreach ($areafiles as $f) {
+            if ($f->is_directory()) {
+                // Skip directories.
+                continue;
+            }
+            $files[] = $f;
+        }
+        return $files;
     }
 
 }

--- a/locallib.php
+++ b/locallib.php
@@ -363,7 +363,7 @@ class ratingallocate {
             $data = new stdClass();
             $options = array('subdirs' => false, 'maxfiles' => -1, 'accepted_types' => '*', 'return_types' => FILE_INTERNAL);
             file_prepare_standard_filemanager($data, 'attachments', $options, $this->context,
-                'ratingallocate', 'choice_attachment', $choiceid);
+                'mod_ratingallocate', 'choice_attachment', $choiceid);
 
             $mform = new modify_choice_form(new moodle_url('/mod/ratingallocate/view.php',
                 array('id' => $this->coursemodule->id,
@@ -382,7 +382,7 @@ class ratingallocate {
                         $this->save_modify_choice_form($data);
 
                         $data = file_postupdate_standard_filemanager($data, 'attachments', $options, $this->context,
-                            'ratingallocate', 'choice_attachment', $data->choiceid);
+                            'mod_ratingallocate', 'choice_attachment', $data->choiceid);
                         $renderer->add_notification(get_string("choice_added_notification", ratingallocate_MOD_NAME),
                         self::NOTIFY_SUCCESS);
 
@@ -1568,7 +1568,7 @@ class ratingallocate {
      * @return array of file objects.
      */
     public function get_file_attachments_for_choice($choiceid) {
-        $areafiles = get_file_storage()->get_area_files($this->context->id, "ratingallocate", "choice_attachment", $choiceid);
+        $areafiles = get_file_storage()->get_area_files($this->context->id, 'mod_ratingallocate', 'choice_attachment', $choiceid);
         $files = array();
         foreach ($areafiles as $f) {
             if ($f->is_directory()) {

--- a/renderer.php
+++ b/renderer.php
@@ -446,7 +446,7 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
             $explanation = $choice->{this_db\ratingallocate_choices::EXPLANATION};
             $attachments = $ratingallocate->get_file_attachments_for_choice($choice->id);
             if ($attachments) {
-                $explanation .= $this->render_attachments($attachments);
+                $explanation .= $this->render_attachments($attachments, true);
             }
             $row[] = $explanation;
             $row[] = $choice->{this_db\ratingallocate_choices::MAXSIZE};
@@ -471,10 +471,11 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
 
     /**
      * Render file attachments for a certain choice entry
-     * @param array $files array of file attachments
+     * @param array $files Array of file attachments
+     * @param bool $break Insert a line break on the first file attachment
      * @return string HTML for the attachments
      */
-    public function render_attachments($files) {
+    public function render_attachments($files, $break=false) {
         $entries = array();
         foreach ($files as $f) {
             $filename = $f->get_filename();
@@ -491,7 +492,13 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
                 'title' => $filename,
             );
 
-            $entry = html_writer::empty_tag('br');
+            $entry = '';
+            if (!$break) {
+                // Skip first line break; update flag for any subsequent attachments.
+                $break = true;
+            } else {
+                $entry .= html_writer::empty_tag('br');
+            }
             $entry .= html_writer::start_tag('a', $a);
             $entry .= $this->output->image_icon('t/right', $filename, 'moodle', array('title' => 'Download file'));
             $entry .= $filename;
@@ -499,7 +506,6 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
             $entries[] = $entry;
         }
         return implode($entries);
-
     }
 
     /**

--- a/renderer.php
+++ b/renderer.php
@@ -443,7 +443,12 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
             $row = array();
             $class = '';
             $row[] = $choice->{this_db\ratingallocate_choices::TITLE};
-            $row[] = $choice->{this_db\ratingallocate_choices::EXPLANATION};
+            $explanation = $choice->{this_db\ratingallocate_choices::EXPLANATION};
+            $attachments = $ratingallocate->get_file_attachments_for_choice($choice->id);
+            if ($attachments) {
+                $explanation .= $this->render_attachments($attachments);
+            }
+            $row[] = $explanation;
             $row[] = $choice->{this_db\ratingallocate_choices::MAXSIZE};
             if ($choice->{this_db\ratingallocate_choices::ACTIVE}) {
                 $row[] = get_string('yes');
@@ -462,6 +467,39 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
         }
 
         $table->finish_output();
+    }
+
+    /**
+     * Render file attachments for a certain choice entry
+     * @param array $files array of file attachments
+     * @return string HTML for the attachments
+     */
+    private function render_attachments($files) {
+        $entries = array();
+        foreach ($files as $f) {
+            $filename = $f->get_filename();
+            $url = moodle_url::make_pluginfile_url(
+                $f->get_contextid(),
+                $f->get_component(),
+                $f->get_filearea(),
+                $f->get_itemid(),
+                $f->get_filepath(),
+                $f->get_filename(),
+                false);
+            $a = array(
+                'href' => $url,
+                'title' => $filename,
+            );
+
+            $entry = html_writer::empty_tag('br');
+            $entry .= html_writer::start_tag('a', $a);
+            $entry .= $this->output->image_icon('t/right', $filename, 'moodle', array('title' => 'Download file'));
+            $entry .= $filename;
+            $entry .= html_writer::end_tag('a');
+            $entries[] = $entry;
+        }
+        return implode($entries);
+
     }
 
     /**

--- a/renderer.php
+++ b/renderer.php
@@ -474,7 +474,7 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
      * @param array $files array of file attachments
      * @return string HTML for the attachments
      */
-    private function render_attachments($files) {
+    public function render_attachments($files) {
         $entries = array();
         foreach ($files as $f) {
             $filename = $f->get_filename();

--- a/strategy/strategy04_points.php
+++ b/strategy/strategy04_points.php
@@ -123,6 +123,10 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
             $mform->addElement('text', $ratingelem, $data->explanation );
             $mform->setType($ratingelem, PARAM_INT);
 
+            // Render any file attachments.
+            $attachments = $this->ratingallocate->get_file_attachments_for_choice($data->choiceid);
+            $mform->addElement('static', 'file', $this->ratingallocate->get_renderer()->render_attachments($attachments));
+
             // try to restore previous ratings
             if (is_numeric($data->rating) && $data->rating >= 0) {
                 $mform->setDefault($ratingelem, $data->rating);

--- a/strategy/strategy04_points.php
+++ b/strategy/strategy04_points.php
@@ -125,7 +125,7 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
 
             // Render any file attachments.
             $attachments = $this->ratingallocate->get_file_attachments_for_choice($data->choiceid);
-            $mform->addElement('static', 'file', $this->ratingallocate->get_renderer()->render_attachments($attachments));
+            $mform->addElement('html', $this->ratingallocate->get_renderer()->render_attachments($attachments));
 
             // try to restore previous ratings
             if (is_numeric($data->rating) && $data->rating >= 0) {

--- a/strategy/strategy05_order.php
+++ b/strategy/strategy05_order.php
@@ -136,6 +136,10 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
                 get_string('choice_maxsize_display', ratingallocate_MOD_NAME) .
                 ':</span> <span class="mod-ratingallocate-choice-maxno-value">' . $data->maxsize . '</span></div>');
             $mform->addElement('static', 'description_'.$data->choiceid, $data->title, $data->explanation);
+
+            // Render any file attachments.
+            $attachments = $this->ratingallocate->get_file_attachments_for_choice($data->choiceid);
+            $mform->addElement('static', 'file', $this->ratingallocate->get_renderer()->render_attachments($attachments));
         }
     }
 

--- a/strategy/strategy05_order.php
+++ b/strategy/strategy05_order.php
@@ -139,7 +139,7 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
 
             // Render any file attachments.
             $attachments = $this->ratingallocate->get_file_attachments_for_choice($data->choiceid);
-            $mform->addElement('static', 'file', $this->ratingallocate->get_renderer()->render_attachments($attachments));
+            $mform->addElement('html', $this->ratingallocate->get_renderer()->render_attachments($attachments));
         }
     }
 

--- a/strategy/strategy06_tickyes.php
+++ b/strategy/strategy06_tickyes.php
@@ -136,6 +136,10 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
             } else {
                 $mform->setDefault($ratingelem, 1);
             }
+
+            // Render any file attachments.
+            $attachments = $this->ratingallocate->get_file_attachments_for_choice($data->choiceid);
+            $mform->addElement('static', 'file', $this->ratingallocate->get_renderer()->render_attachments($attachments));
         }
     }
 

--- a/strategy/strategy06_tickyes.php
+++ b/strategy/strategy06_tickyes.php
@@ -139,7 +139,7 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
 
             // Render any file attachments.
             $attachments = $this->ratingallocate->get_file_attachments_for_choice($data->choiceid);
-            $mform->addElement('static', 'file', $this->ratingallocate->get_renderer()->render_attachments($attachments));
+            $mform->addElement('html', $this->ratingallocate->get_renderer()->render_attachments($attachments));
         }
     }
 

--- a/strategy/strategy_template_options.php
+++ b/strategy/strategy_template_options.php
@@ -106,12 +106,9 @@ abstract class ratingallocate_options_strategyform extends \ratingallocate_strat
             // Furthermore, use explanation as title/label of group.
             $mform->addGroup($radioarray, 'radioarr_' . $data->choiceid, $data->explanation, null, false);
 
+            // Render any file attachments.
             $attachments = $this->ratingallocate->get_file_attachments_for_choice($data->choiceid);
-            $entries = array();
-            foreach ($attachments as $f) {
-                $entries[] = '<br/>* ' . $f->get_filename();
-            }
-            $mform->addElement('static', 'file', implode($entries));
+            $mform->addElement('static', 'file', $this->ratingallocate->get_renderer()->render_attachments($attachments));
 
             $defaultrating = $this->get_strategysetting('default');
             $defaultrating = $defaultrating == null ? max(array_keys($choiceoptions)) : $defaultrating;

--- a/strategy/strategy_template_options.php
+++ b/strategy/strategy_template_options.php
@@ -108,7 +108,7 @@ abstract class ratingallocate_options_strategyform extends \ratingallocate_strat
 
             // Render any file attachments.
             $attachments = $this->ratingallocate->get_file_attachments_for_choice($data->choiceid);
-            $mform->addElement('static', 'file', $this->ratingallocate->get_renderer()->render_attachments($attachments));
+            $mform->addElement('html', $this->ratingallocate->get_renderer()->render_attachments($attachments));
 
             $defaultrating = $this->get_strategysetting('default');
             $defaultrating = $defaultrating == null ? max(array_keys($choiceoptions)) : $defaultrating;

--- a/strategy/strategy_template_options.php
+++ b/strategy/strategy_template_options.php
@@ -106,6 +106,13 @@ abstract class ratingallocate_options_strategyform extends \ratingallocate_strat
             // Furthermore, use explanation as title/label of group.
             $mform->addGroup($radioarray, 'radioarr_' . $data->choiceid, $data->explanation, null, false);
 
+            $attachments = $this->ratingallocate->get_file_attachments_for_choice($data->choiceid);
+            $entries = array();
+            foreach ($attachments as $f) {
+                $entries[] = '<br/>* ' . $f->get_filename();
+            }
+            $mform->addElement('static', 'file', implode($entries));
+
             $defaultrating = $this->get_strategysetting('default');
             $defaultrating = $defaultrating == null ? max(array_keys($choiceoptions)) : $defaultrating;
             // Try to restore previous ratings.


### PR DESCRIPTION
This code adds the ability to upload file attachments associated with choices in a ratingallocate activity, so that supplementary information files (e.g. PDFs) can be provided to learners.

This adds a filemanager element to the form when editing choice values, and uses the `ratingallocate_pluginfile` handler to allow learners to view or download file attachments when they have the view capability within the module context. Files are associated with a "choice_attachment" file area.

The rendering of file attachment links has been added to the `ratingallocate_options_strategyform` common to the first three strategies, and individually to the forms of the other three strategies.