### PR TITLE
Use HTML editor for choice explanations.

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/ratingallocate/db" VERSION="20141118" COMMENT="XMLDB file for Moodle mod/ratingallocate"
+<XMLDB PATH="mod/ratingallocate/db" VERSION="20210629" COMMENT="XMLDB file for Moodle mod/ratingallocate"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -36,7 +36,7 @@
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="ratingallocateid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="reference to the instance of ratingallocate it belongs to"/>
         <FIELD NAME="title" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="explanation" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="explanation" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="maxsize" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="10" SEQUENCE="false"/>
         <FIELD NAME="active" TYPE="int" LENGTH="4" NOTNULL="false" DEFAULT="1" SEQUENCE="false" COMMENT="ob man in die Wahl bewerten kann oder ob sie &quot;versteckt&quot; ist"/>
       </FIELDS>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -131,6 +131,19 @@ function xmldb_ratingallocate_upgrade($oldversion) {
         }
 
     }
-    
+
+    if ($oldversion < 2021062900) {
+
+        // Changing type of field explanation on table ratingallocate_choices to text.
+        $table = new xmldb_table('ratingallocate_choices');
+        $field = new xmldb_field('explanation', XMLDB_TYPE_TEXT, null, null, null, null, null, 'title');
+
+        // Launch change of type for field explanation.
+        $dbman->change_field_type($table, $field);
+
+        // Ratingallocate savepoint reached.
+        upgrade_mod_savepoint(true, 2021062900, 'ratingallocate');
+    }
+
     return true;
 }

--- a/form_modify_choice.php
+++ b/form_modify_choice.php
@@ -53,6 +53,11 @@ class modify_choice_form extends moodleform {
         $this->ratingallocate = $ratingallocate;
         if ($choice) {
             $this->choice = $choice;
+            // Special handling for HTML editor.
+            $this->choice->explanation = array(
+                'text' => $this->choice->explanation,
+                'format' => FORMAT_HTML,
+            );
         } else {
             $this->addnew = true;
         }
@@ -75,8 +80,11 @@ class modify_choice_form extends moodleform {
         $mform->addRule($elementname, get_string('err_required', 'form') , 'required', null, 'server');
 
         $elementname = 'explanation';
-        $mform->addElement('text', $elementname, get_string('choice_explanation', ratingallocate_MOD_NAME));
-        $mform->setType($elementname, PARAM_TEXT);
+        $editoroptions = array(
+            'enable_filemanagement' => false,
+        );
+        $mform->addElement('editor', $elementname, get_string('choice_explanation', ratingallocate_MOD_NAME), $editoroptions);
+        $mform->setType($elementname, PARAM_RAW);
 
         $elementname = 'maxsize';
         $mform->addElement('text', $elementname, get_string('choice_maxsize', ratingallocate_MOD_NAME));

--- a/locallib.php
+++ b/locallib.php
@@ -1068,7 +1068,7 @@ class ratingallocate {
                 $notificationtext = get_string('allocation_notification_message', 'ratingallocate', array(
                     'ratingallocate' => $this->ratingallocate->name,
                     'choice' => $choices[$allocchoiceid]->title,
-                    'explanation' => $choices[$allocchoiceid]->explanation));
+                    'explanation' => format_text($choices[$allocchoiceid]->explanation)));
             } else {
                 $notificationtext = get_string('no_allocation_notification_message', 'ratingallocate', array(
                     'ratingallocate' => $this->ratingallocate->name));

--- a/locallib.php
+++ b/locallib.php
@@ -370,6 +370,11 @@ class ratingallocate {
             if ($mform->is_submitted() && $data = $mform->get_submitted_data()) {
                 if (!$mform->is_cancelled()) {
                     if ($mform->is_validated()) {
+                        // Processing for editor element (FORMAT_HTML is assumed).
+                        // Note: No file management implemented at this point.
+                        if (is_array($data->explanation)) {
+                            $data->explanation = $data->explanation['text'];
+                        }
                         $this->save_modify_choice_form($data);
                         $renderer->add_notification(get_string("choice_added_notification", ratingallocate_MOD_NAME),
                             self::NOTIFY_SUCCESS);

--- a/renderer.php
+++ b/renderer.php
@@ -189,7 +189,7 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
                     $allocation_html .= html_writer::span(
                         format_string($allocation->{this_db\ratingallocate_choices::TITLE}),
                         'allocation tag tag-success');
-                    $allocation_html .= '<br/>' . format_string($allocation->{this_db\ratingallocate_choices::EXPLANATION});
+                    $allocation_html .= '<br/>' . format_text($allocation->{this_db\ratingallocate_choices::EXPLANATION});
                 }
                 $cell2 = new html_table_cell($allocation_html);
                 $row->cells = array($cell1, $cell2);
@@ -443,7 +443,7 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
             $row = array();
             $class = '';
             $row[] = $choice->{this_db\ratingallocate_choices::TITLE};
-            $row[] = $choice->{this_db\ratingallocate_choices::EXPLANATION};
+            $row[] = format_text($choice->{this_db\ratingallocate_choices::EXPLANATION});
             $row[] = $choice->{this_db\ratingallocate_choices::MAXSIZE};
             if ($choice->{this_db\ratingallocate_choices::ACTIVE}) {
                 $row[] = get_string('yes');

--- a/strategy/strategy04_points.php
+++ b/strategy/strategy04_points.php
@@ -120,7 +120,7 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
                 ':</span> <span class="mod-ratingallocate-choice-maxno-value">' . $data->maxsize . '</span></div>');
 
             // Use explanation as title/label of group to align with other strategies.
-            $mform->addElement('text', $ratingelem, $data->explanation );
+            $mform->addElement('text', $ratingelem, format_text($data->explanation));
             $mform->setType($ratingelem, PARAM_INT);
 
             // try to restore previous ratings

--- a/strategy/strategy05_order.php
+++ b/strategy/strategy05_order.php
@@ -135,7 +135,7 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
                 '<span class="mod-ratingallocate-choice-maxno-desc">' .
                 get_string('choice_maxsize_display', ratingallocate_MOD_NAME) .
                 ':</span> <span class="mod-ratingallocate-choice-maxno-value">' . $data->maxsize . '</span></div>');
-            $mform->addElement('static', 'description_'.$data->choiceid, $data->title, $data->explanation);
+            $mform->addElement('static', 'description_'.$data->choiceid, $data->title, format_text($data->explanation));
         }
     }
 

--- a/strategy/strategy06_tickyes.php
+++ b/strategy/strategy06_tickyes.php
@@ -128,7 +128,7 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
                 ':</span> <span class="mod-ratingallocate-choice-maxno-value">' . $data->maxsize . '</span></div>');
 
             // Use explanation as title/label of checkbox to align with other strategies.
-            $mform->addElement('advcheckbox', $ratingelem, $data->explanation, $this->get_strategy()->get_accept_label(), null, array(0, 1));
+            $mform->addElement('advcheckbox', $ratingelem, format_text($data->explanation), $this->get_strategy()->get_accept_label(), null, array(0, 1));
             $mform->setType($ratingelem, PARAM_INT);
 
             if (is_numeric($data->rating) && $data->rating >= 0) {

--- a/strategy/strategy_template_options.php
+++ b/strategy/strategy_template_options.php
@@ -104,7 +104,7 @@ abstract class ratingallocate_options_strategyform extends \ratingallocate_strat
 
             // It is important to set a group name, so that later on errors can be displayed at the correct spot.
             // Furthermore, use explanation as title/label of group.
-            $mform->addGroup($radioarray, 'radioarr_' . $data->choiceid, $data->explanation, null, false);
+            $mform->addGroup($radioarray, 'radioarr_' . $data->choiceid, format_text($data->explanation), null, false);
 
             $defaultrating = $this->get_strategysetting('default');
             $defaultrating = $defaultrating == null ? max(array_keys($choiceoptions)) : $defaultrating;

--- a/tests/behat/allocation_status.feature
+++ b/tests/behat/allocation_status.feature
@@ -26,7 +26,7 @@ Feature: Students should get status information according to their rating and th
     And I press "Edit Choices"
     And I add a new choice with the values:
       | title       | My only choice |
-      | explanation | Test           |
+      | Description (optional) | Test           |
       | maxsize     |	1            |
     And I log out
     And I log in as "student1"

--- a/tests/behat/defaultratings.feature
+++ b/tests/behat/defaultratings.feature
@@ -23,11 +23,11 @@ Feature: When a student starts a rating the default values of all choices
     And I press "Edit Choices"
     And I add a new choice with the values:
       | title       | My first choice |
-      | explanation | Test 1          |
+      | Description (optional) | Test 1          |
       | maxsize     |	2	    	  |
     And I add a new choice with the values:
       | title       | My second choice |
-      | explanation | Test 1          |
+      | Description (optional) | Test 1          |
       | maxsize     |	2	    	  |
 
   @javascript

--- a/tests/behat/mod_form.feature
+++ b/tests/behat/mod_form.feature
@@ -22,21 +22,21 @@ Feature: Creating a new rating allocation, where new choices need to
     And I press "Edit Choices"
     And I add a new choice with the values:
       | title       | My first choice |
-      | explanation | Test 1          |
+      | Description (optional) | Test 1          |
       | maxsize     |	2	    	  |
     And I add a new choice with the values:
       | title       | My second choice |
-      | explanation | Test 2           |
+      | Description (optional) | Test 2           |
       | maxsize     |	2	    	   |
     And I add a new choice with the values:
       | title       | My third choice |
-      | explanation | Test 3  		  |
+      | Description (optional) | Test 3  		  |
       | maxsize     |	2	    	  |
 
   Scenario: Create a new rating alloation and add an additonal new choice.
     Given I add a new choice with the values:
   	| title       | My fourth choice |
-  	| explanation | Test 4           |
+  	| Description (optional) | Test 4           |
     | maxsize     |	2	    	     |
     Then I should see the choice with the title "My first choice"
     And I should see the choice with the title "My second choice"
@@ -45,7 +45,7 @@ Feature: Creating a new rating allocation, where new choices need to
 
   Scenario: Create a new rating alloation and add two additonal new choices using the add next button.
     Given I add new choices with the values:
-  	| title            | explanation     | maxsize |
+  	| title            | Description (optional)    | maxsize |
     | My fourth choice | Test 4          | 2       |
     | My fifth choice  | Test 5          | 2       |
     Then I should see the choice with the title "My first choice"
@@ -56,7 +56,7 @@ Feature: Creating a new rating allocation, where new choices need to
 
   Scenario: Create a new rating alloation and add two additonal new choices, but delete two old and one new.
     When I add new choices with the values:
-      | title            | explanation     | maxsize |
+      | title            | Description (optional)    | maxsize |
       | My fourth choice | Test 4          | 2       |
       | My fifth choice  | Test 5          | 2       |
     And I delete the choice with the title "My first choice"
@@ -72,7 +72,7 @@ Feature: Creating a new rating allocation, where new choices need to
   Scenario: Create a new rating alloation and add an additonal new active choice.
     When I add a new choice with the values:
       | title       | My fourth choice |
-      | explanation | Test 4          |
+      | Description (optional) | Test 4          |
       | maxsize     |	1337			|
       | active      | true            |
     And I should see the choice with the title "My fourth choice"
@@ -83,7 +83,7 @@ Feature: Creating a new rating allocation, where new choices need to
   Scenario: Create a new rating alloation and add an additonal new inactive choice.
     When I add a new choice with the values:
       | title       | My fourth choice |
-      | explanation | Test 4          |
+      | Description (optional) | Test 4          |
       | maxsize     |	1337			|
       | active      | false            |
     And I should see the choice with the title "My fourth choice"
@@ -94,7 +94,7 @@ Feature: Creating a new rating allocation, where new choices need to
   Scenario: Create a new rating alloation and add an additonal new inactive choice. Change the the choice to active.
     When I add a new choice with the values:
       | title       | My fourth choice |
-      | explanation | This is my discription          |
+      | Description (optional) | This is my discription          |
       | maxsize     |	1231243			|
       | active	  | false				|
     Then I set the choice with the title "My fourth choice" to active
@@ -104,7 +104,7 @@ Feature: Creating a new rating allocation, where new choices need to
   Scenario: Create a new rating alloation and add an additonal new active choice. Change the the choice to inactive.
     When I add a new choice with the values:
       | title       | My fourth choice |
-      | explanation | This is my discription          |
+      | Description (optional) | This is my discription          |
       | maxsize     |	1231243			|
       | active	  | true				|
     Then I set the choice with the title "My fourth choice" to inactive

--- a/tests/behat/ratings.feature
+++ b/tests/behat/ratings.feature
@@ -22,15 +22,15 @@ Feature: When a student rates a rating should be saved and it should be possible
     And I press "Edit Choices"
     And I add a new choice with the values:
       | title       | My first choice |
-      | explanation | Test 1          |
+      | Description (optional) | Test 1          |
       | maxsize     |	2	    	  |
     And I add a new choice with the values:
       | title       | My second choice |
-      | explanation | Test 2           |
+      | Description (optional) | Test 2           |
       | maxsize     |	2	    	   |
     And I add a new choice with the values:
       | title       | My third choice |
-      | explanation | Test 3  		  |
+      | Description (optional) | Test 3  		  |
       | maxsize     |	2	    	  |
     And I log out
 

--- a/tests/behat/validate_rating.feature
+++ b/tests/behat/validate_rating.feature
@@ -24,19 +24,19 @@ Feature: When a student attempts to rate choices it should be validated prior to
     And I press "Edit Choices"
     And I add a new choice with the values:
       | title       | My first choice |
-      | explanation | Test 1          |
+      | Description (optional) | Test 1          |
       | maxsize     |	2	    	  |
     And I add a new choice with the values:
       | title       | My second choice |
-      | explanation | Test 2           |
+      | Description (optional) | Test 2           |
       | maxsize     |	2	    	   |
     And I add a new choice with the values:
       | title       | My third choice |
-      | explanation | Test 3  		  |
+      | Description (optional) | Test 3  		  |
       | maxsize     |	2	    	  |
     And I add a new choice with the values:
       | title       | My fourth choice |
-      | explanation | Test 4  		  |
+      | Description (optional) | Test 4  		  |
       | maxsize     |	2	    	  |
     And I log out
 

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020111200;        // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2021062900;        // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2017111300;        // Requires this Moodle version
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = 'v3.10-r1';


### PR DESCRIPTION
Changes the choice explanation element from 'text' to 'editor'.

Text in existing choices will be rendered as normal; explanations will be updated to HTML format whenever the form is next edited.

Internal file management / upload is presently disabled, but external image and file URLs can be inserted via the editor, supporting embedding within the explanation markup.