### PR TITLE
Feature: Add per choice upper limit for give points strategy

### DIFF
--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -274,9 +274,11 @@ $string['strategy_points_name'] = 'Give Points';
 $string['strategy_points_setting_maxzero'] = 'Maximum number of choices to which the user can give 0 points';
 $string['strategy_points_explain_distribute_points'] = 'Give points to each choice, you have a total of {$a} points to distribute. Prioritize the best choice by giving the most points.';
 $string['strategy_points_explain_max_zero'] = 'You may only assign 0 points to at most {$a} choice(s).';
+$string['strategy_points_explain_max_per_choice'] = 'You may at most assign {$a} points to a single choice.';
 $string['strategy_points_incorrect_totalpoints'] = 'Incorrect total number of points. The sum of all points has to be {$a}.';
 $string['strategy_points_setting_totalpoints'] = 'Total number of points the user can assign';
 $string['strategy_points_max_count_zero'] = 'You may give 0 points to at most {$a} choice(s).';
+$string['strategy_points_setting_maxperchoice'] = 'Maximum number of points the user may give to a single choice';
 $string['strategy_points_illegal_entry'] = 'The points that you assign to a choice must be between 0 and {$a}.';
 
 // Specific to Strategy05, Order

--- a/strategy/strategy04_points.php
+++ b/strategy/strategy04_points.php
@@ -39,6 +39,7 @@ class strategy extends \strategytemplate {
     const STRATEGYID = 'strategy_points';
     const MAXZERO = 'maxzero';
     const TOTALPOINTS = 'totalpoints';
+    const MAXPERCHOICE = 'maxperchoice';
 
 
     public function get_strategyid() {
@@ -58,6 +59,12 @@ class strategy extends \strategytemplate {
                 get_string(self::STRATEGYID . '_setting_totalpoints', ratingallocate_MOD_NAME),
                 $this->get_settings_value(self::TOTALPOINTS),
                 null
+            ),
+            self::MAXPERCHOICE => array( // wie viele Punkte man maximal pro Wahlmoeglichkeit vergeben kann
+                'int',
+                get_string(self::STRATEGYID . '_setting_maxperchoice', ratingallocate_MOD_NAME),
+                $this->get_settings_value(self::MAXPERCHOICE),
+                null
             )
         );
     }
@@ -69,13 +76,15 @@ class strategy extends \strategytemplate {
     public function get_default_settings() {
         return array(
                         self::MAXZERO => 3,
-                        self::TOTALPOINTS => 100
+                        self::TOTALPOINTS => 100,
+                        self::MAXPERCHOICE => 100
         );
     }
 
     protected function getValidationInfo() {
         return array(self::MAXZERO => array(true,0),
-                     self::TOTALPOINTS => array(true,1)
+                     self::TOTALPOINTS => array(true,1),
+                     self::MAXPERCHOICE => array(true,1)
         );
     }
 
@@ -140,12 +149,15 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
         $output = get_string(strategy::STRATEGYID . '_explain_distribute_points', ratingallocate_MOD_NAME, $this->get_strategysetting(strategy::TOTALPOINTS));
         $output .= '<br />';
         $output .= get_string(strategy::STRATEGYID . '_explain_max_zero', ratingallocate_MOD_NAME, $this->get_strategysetting(strategy::MAXZERO));
+        $output .= '<br />';
+        $output .= get_string(strategy::STRATEGYID . '_explain_max_per_choice', ratingallocate_MOD_NAME, $this->get_strategysetting(strategy::MAXPERCHOICE));
         return $output;
     }
 
     public function validation($data, $files) {
         $maxcrossout = $this->get_strategysetting(strategy::MAXZERO);
         $totalpoints = $this->get_strategysetting(strategy::TOTALPOINTS);
+        $maxperchoice = $this->get_strategysetting(strategy::MAXPERCHOICE);
         $errors = parent::validation($data, $files);
 
         if (!array_key_exists('data', $data) or count($data ['data']) < 2) {
@@ -156,7 +168,7 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
         $ratings = $data ['data'];
         $currentpoints = 0;
         foreach ($ratings as $cid => $rating) {
-            if ($rating['rating'] < 0 || $rating['rating'] > $totalpoints) {
+            if ($rating['rating'] < 0 || $rating['rating'] > $totalpoints || $rating['rating'] > $maxperchoice) {
                 $errors['data[' . $cid . '][rating]'] = get_string(strategy::STRATEGYID . '_illegal_entry', ratingallocate_MOD_NAME, $totalpoints);
             } else if ($rating ['rating'] == 0) {
                 $impossibles ++;

--- a/tests/mod_ratingallocate_strategy_test.php
+++ b/tests/mod_ratingallocate_strategy_test.php
@@ -106,6 +106,10 @@ class mod_ratingallocate_strategy_testcase extends advanced_testcase {
         $settings = array(ratingallocate\strategy_points\strategy::TOTALPOINTS => null);
         $strategy = new ratingallocate\strategy_points\strategy($settings);
         $this->assertCount(1, $strategy->validate_settings());
+        //Attribute required
+        $settings = array(ratingallocate\strategy_points\strategy::MAXPERCHOICE => null);
+        $strategy = new ratingallocate\strategy_points\strategy($settings);
+        $this->assertCount(1, $strategy->validate_settings());
         //Attribute minimum error
         $settings = array(ratingallocate\strategy_points\strategy::MAXZERO => -1);
         $strategy = new ratingallocate\strategy_points\strategy($settings);
@@ -114,12 +118,20 @@ class mod_ratingallocate_strategy_testcase extends advanced_testcase {
         $settings = array(ratingallocate\strategy_points\strategy::TOTALPOINTS => 0);
         $strategy = new ratingallocate\strategy_points\strategy($settings);
         $this->assertCount(1, $strategy->validate_settings());
+        //Attribute minimum error
+        $settings = array(ratingallocate\strategy_points\strategy::MAXPERCHOICE => 0);
+        $strategy = new ratingallocate\strategy_points\strategy($settings);
+        $this->assertCount(1, $strategy->validate_settings());
         //No validation error
         $settings = array(ratingallocate\strategy_points\strategy::MAXZERO => 0);
         $strategy = new ratingallocate\strategy_points\strategy($settings);
         $this->assertCount(0, $strategy->validate_settings());
         //No validation error
         $settings = array(ratingallocate\strategy_points\strategy::TOTALPOINTS => 1);
+        $strategy = new ratingallocate\strategy_points\strategy($settings);
+        $this->assertCount(0, $strategy->validate_settings());
+        //No validation error
+        $settings = array(ratingallocate\strategy_points\strategy::MAXPERCHOICE => 1);
         $strategy = new ratingallocate\strategy_points\strategy($settings);
         $this->assertCount(0, $strategy->validate_settings());
     }

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021062900;        // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2022012201;        // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2017111300;        // Requires this Moodle version
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = 'v3.10-r1';


### PR DESCRIPTION
Closes #227 

See issue for description.

Implementation details:
- This is only a "frontend" change: the choice form doesn't accept distribution of points where one choice receives more than the allowed amount of points per choice
- Everything else is being left untouched by this PR
- Kudos to whoever wrote this part of the code, it made it extremely convenient to add this feature :-)
- I set the default value to the same amount as the total max points, so there shouldn't be any usability problems for users with this update

I also tested applying the new version of the plugin to already existing instances, but couldn't spot any problems (which seems reasonable, because it's only a frontend form change :-)

Any kind of feedback always welcome!