### PR TITLE
Group mode (replaces #242, adds requests from code review)

### DIFF
--- a/backup/moodle2/backup_ratingallocate_activity_stepslib.php
+++ b/backup/moodle2/backup_ratingallocate_activity_stepslib.php
@@ -50,7 +50,13 @@ class backup_ratingallocate_activity_structure_step extends backup_activity_stru
         $ratingallocate_allocations = new backup_nested_element(get_tablename_for_tableClass($class) . 's');
         $ratingallocate_allocation = new backup_nested_element(get_tablename_for_tableClass($class), get_id_for_tableClass($class), get_fields_for_tableClass($class));
 
-        // Build the tree
+        $groupchoiceclass = 'ratingallocate\db\ratingallocate_group_choices';
+        $groupchoices = new backup_nested_element(get_tablename_for_tableClass($groupchoiceclass) . 's');
+        $groupchoice = new backup_nested_element(get_tablename_for_tableClass($groupchoiceclass),
+                                                 get_id_for_tableClass($groupchoiceclass),
+                                                 get_fields_for_tableClass($groupchoiceclass));
+
+        // Build the tree.
         $ratingallocate->add_child($ratingallocate_choices);
         $ratingallocate_choices->add_child($ratingallocate_choice);
 
@@ -60,9 +66,13 @@ class backup_ratingallocate_activity_structure_step extends backup_activity_stru
         $ratingallocate_choice->add_child($ratingallocate_allocations);
         $ratingallocate_allocations->add_child($ratingallocate_allocation);
 
+        $ratingallocate_choice->add_child($groupchoices);
+        $groupchoices->add_child($groupchoice);
+
         // Define sources
         $ratingallocate->set_source_table(get_tablename_for_tableClass('ratingallocate\db\ratingallocate'), array(this_db\ratingallocate::ID => backup::VAR_ACTIVITYID), this_db\ratingallocate_choices::ID . ' ASC');
         $ratingallocate_choice->set_source_table(get_tablename_for_tableClass('ratingallocate\db\ratingallocate_choices'), array(this_db\ratingallocate_choices::RATINGALLOCATEID => backup::VAR_PARENTID), this_db\ratingallocate_choices::ID . ' ASC');
+        $groupchoice->set_source_table(get_tablename_for_tableClass($groupchoiceclass), ['choiceid' => backup::VAR_PARENTID]);
 
         if ($userinfo) {
             $ratingallocate_rating->set_source_table(get_tablename_for_tableClass('ratingallocate\db\ratingallocate_ratings'), array(this_db\ratingallocate_ratings::CHOICEID => backup::VAR_PARENTID), this_db\ratingallocate_ratings::ID . ' ASC');
@@ -72,6 +82,7 @@ class backup_ratingallocate_activity_structure_step extends backup_activity_stru
         // Define id annotations
         $ratingallocate_allocation->annotate_ids('user', this_db\ratingallocate_allocations::USERID);
         $ratingallocate_rating->annotate_ids('user', this_db\ratingallocate_ratings::USERID);
+        $groupchoice->annotate_ids('group', 'groupid');
 
         // Define file annotations
         $ratingallocate->annotate_files('mod_' . ratingallocate_MOD_NAME, 'intro', null);

--- a/backup/moodle2/restore_ratingallocate_activity_stepslib.php
+++ b/backup/moodle2/restore_ratingallocate_activity_stepslib.php
@@ -33,6 +33,8 @@ class restore_ratingallocate_activity_structure_step extends restore_activity_st
         $paths[] = new restore_path_element(this_db\ratingallocate::TABLE, $ratingallocate_path );
         $choices_path = $ratingallocate_path . '/' . this_db\ratingallocate_choices::TABLE . 's/' . this_db\ratingallocate_choices::TABLE;
         $paths[] = new restore_path_element(this_db\ratingallocate_choices::TABLE, $choices_path);
+        $paths[] = new restore_path_element(this_db\ratingallocate_group_choices::TABLE,
+                                            $choices_path .'/' . this_db\ratingallocate_group_choices::TABLE .'s/' . this_db\ratingallocate_group_choices::TABLE);
         if ($userinfo) {
             $paths[] = new restore_path_element(this_db\ratingallocate_ratings::TABLE,     $choices_path .'/' . this_db\ratingallocate_ratings::TABLE .'s/' . this_db\ratingallocate_ratings::TABLE);
             $paths[] = new restore_path_element(this_db\ratingallocate_allocations::TABLE, $choices_path .'/' . this_db\ratingallocate_allocations::TABLE .'s/' . this_db\ratingallocate_allocations::TABLE);
@@ -98,6 +100,25 @@ class restore_ratingallocate_activity_structure_step extends restore_activity_st
 
         $newitemid = $DB->insert_record(this_db\ratingallocate_allocations::TABLE, $data);
         $this->set_mapping(this_db\ratingallocate_allocations::TABLE, $oldid, $newitemid);
+    }
+
+    /**
+     * Process group choices restore data.
+     *
+     * @param array $data
+     * @return void
+     */
+    protected function process_ratingallocate_group_choices($data) {
+        global $DB;
+        $data = (object) $data;
+        $oldid = $data->id;
+        $data->choiceid = $this->get_new_parentid(this_db\ratingallocate_choices::TABLE);
+        if ((int) $data->groupid !== 0) {
+            $data->groupid = $this->get_mappingid('group', $data->groupid);
+        }
+
+        $newitemid = $DB->insert_record(this_db\ratingallocate_group_choices::TABLE, $data);
+        $this->set_mapping(this_db\ratingallocate_group_choices::TABLE, $oldid, $newitemid);
     }
 
     protected function after_execute() {

--- a/db/db_structure.php
+++ b/db/db_structure.php
@@ -51,6 +51,13 @@ class ratingallocate_choices {
     const EXPLANATION = 'explanation';
     const MAXSIZE = 'maxsize';
     const ACTIVE = 'active';
+    const USEGROUPS = 'usegroups';
+}
+class ratingallocate_group_choices {
+    const TABLE = 'ratingallocate_group_choices';
+    const ID = 'id';
+    const CHOICEID = 'choiceid';
+    const GROUPID = 'groupid';
 }
 class ratingallocate_ratings {
     const TABLE = 'ratingallocate_ratings';

--- a/db/install.xml
+++ b/db/install.xml
@@ -31,7 +31,7 @@
         <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
       </INDEXES>
     </TABLE>
-    <TABLE NAME="ratingallocate_choices" COMMENT="Default comment for the table, please edit me">
+    <TABLE NAME="ratingallocate_choices" COMMENT="A choice option within a ratingallocation activity.">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="ratingallocateid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="reference to the instance of ratingallocate it belongs to"/>
@@ -39,6 +39,7 @@
         <FIELD NAME="explanation" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="maxsize" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="10" SEQUENCE="false"/>
         <FIELD NAME="active" TYPE="int" LENGTH="4" NOTNULL="false" DEFAULT="1" SEQUENCE="false" COMMENT="ob man in die Wahl bewerten kann oder ob sie &quot;versteckt&quot; ist"/>
+        <FIELD NAME="usegroups" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Restrict the visibility of this choice to members of specific groups? (1 = Yes, 0 = No)"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
@@ -68,6 +69,18 @@
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
         <KEY NAME="ratingallocateid" TYPE="foreign" FIELDS="ratingallocateid" REFTABLE="ratingallocate" REFFIELDS="id"/>
         <KEY NAME="choiceid" TYPE="foreign" FIELDS="choiceid" REFTABLE="ratingallocate_choices" REFFIELDS="id"/>
+      </KEYS>
+    </TABLE>
+    <TABLE NAME="ratingallocate_group_choices" COMMENT="Group restrictions on individual choice items in a rating allocation activity. When 'usegroups' in {ratingallocate_choices} is true, choices will only be shown to groups specified by entries in this table.">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="choiceid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Reference to a choice item."/>
+        <FIELD NAME="groupid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Reference to a group."/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="choiceid" TYPE="foreign" FIELDS="choiceid" REFTABLE="ratingallocate_choices" REFFIELDS="id"/>
+        <KEY NAME="groupid" TYPE="foreign" FIELDS="groupid" REFTABLE="groups" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
   </TABLES>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -145,5 +145,38 @@ function xmldb_ratingallocate_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2021062900, 'ratingallocate');
     }
 
+    if ($oldversion < 2022120100) {
+
+        // Define table ratingallocate_group_choices to be created.
+        $table = new xmldb_table('ratingallocate_group_choices');
+
+        // Adding fields to table ratingallocate_group_choices.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('choiceid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('groupid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+
+        // Adding keys to table ratingallocate_group_choices.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('choiceid', XMLDB_KEY_FOREIGN, ['choiceid'], 'ratingallocate_choices', ['id']);
+        $table->add_key('groupid', XMLDB_KEY_FOREIGN, ['groupid'], 'groups', ['id']);
+
+        // Conditionally launch create table for ratingallocate_group_choices.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Define field usegroups to be added to ratingallocate_choices.
+        $table = new xmldb_table('ratingallocate_choices');
+        $field = new xmldb_field('usegroups', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', 'active');
+
+        // Conditionally launch add field usegroups.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Ratingallocate savepoint reached.
+        upgrade_mod_savepoint(true, 2022120100, 'ratingallocate');
+    }
+
     return true;
 }

--- a/form_modify_choice.php
+++ b/form_modify_choice.php
@@ -22,10 +22,10 @@
  * @copyright  based on code by M Schulze copyright (C) 2014 M Schulze
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require_once($CFG->dirroot . '/course/moodleform_mod.php');
 require_once(dirname(__FILE__) . '/locallib.php');
-defined('MOODLE_INTERNAL') || die();
 
 /**
  * Provides a form to modify a single choice
@@ -107,12 +107,28 @@ class modify_choice_form extends moodleform {
             null, null, array(0, 1));
         $mform->addHelpButton($elementname, 'choice_active', ratingallocate_MOD_NAME);
 
+        $elementname = 'usegroups';
+        $mform->addelement('advcheckbox', $elementname, get_string('choice_usegroups', ratingallocate_MOD_NAME),
+            null, null, array(0, 1));
+        $mform->addHelpButton($elementname, 'choice_usegroups', ratingallocate_MOD_NAME);
+
+        $elementname = 'groupselector';
+        $options = $this->ratingallocate->get_group_selections();
+        $selector = $mform->addelement('searchableselector', $elementname,
+            get_string('choice_groupselect', ratingallocate_MOD_NAME), $options);
+        $selector->setMultiple(true);
+        $mform->hideIf('groupselector', 'usegroups');
+
         if ($this->choice) {
             $mform->setDefault('title', $this->choice->title);
             $mform->setDefault('explanation', $this->choice->explanation);
             $mform->setDefault('maxsize', $this->choice->maxsize);
             $mform->setDefault('active', $this->choice->active);
+            $mform->setDefault('usegroups', $this->choice->usegroups);
             $mform->setDefault('choiceid', $this->choice->id);
+            // Populate groupselector with IDs of any currently selected groups.
+            $choicegroups = $this->ratingallocate->get_choice_groups($this->choice->id);
+            $mform->setDefault('groupselector', array_keys($choicegroups));
         } else {
             $mform->setDefault('active', true);
         }

--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -201,6 +201,9 @@ $string['choice_maxsize'] = 'Max. number of participants';
 $string['choice_maxsize_display'] = 'Maximum number of students';
 $string['choice_title'] = 'Title';
 $string['choice_title_help'] = 'Title of the choice. *Attention* all active choices will be displayed while ordered by title.';
+$string['choice_usegroups'] = 'Restrict visibility by groups';
+$string['choice_usegroups_help'] = 'If selected, this group will only be visible to the members of the specified groups.';
+$string['choice_groupselect'] = 'Groups';
 $string['edit_choice'] = 'Edit choice';
 $string['rating_endtime'] = 'Rating ends at';
 $string['rating_begintime'] = 'Rating begins at';
@@ -232,6 +235,7 @@ $string['choice_table_title'] = 'Title';
 $string['choice_table_explanation'] = 'Description';
 $string['choice_table_maxsize'] = 'Max. Size';
 $string['choice_table_active'] = 'Active';
+$string['choice_table_usegroups'] = 'Groups';
 $string['choice_table_tools'] = 'Edit';
 // </editor-fold>
 

--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -202,7 +202,9 @@ $string['choice_maxsize_display'] = 'Maximum number of students';
 $string['choice_title'] = 'Title';
 $string['choice_title_help'] = 'Title of the choice. *Attention* all active choices will be displayed while ordered by title.';
 $string['choice_usegroups'] = 'Restrict visibility by groups';
-$string['choice_usegroups_help'] = 'If selected, this group will only be visible to the members of the specified groups.';
+$string['choice_usegroups_help'] = '* If selected, this choice will only be visible to the members of the specified groups.
+* Disabling the restriction means that this choice will be available to anyone.
+* Enabling the restriction without specifying a single group means that this choice will be *not* available for anyone.';
 $string['choice_groupselect'] = 'Groups';
 $string['edit_choice'] = 'Edit choice';
 $string['rating_endtime'] = 'Rating ends at';

--- a/lib.php
+++ b/lib.php
@@ -48,8 +48,7 @@ use ratingallocate\db as this_db;
  * Returns the information on whether the module supports a feature
  *
  * @see plugin_supports() in lib/moodlelib.php
- * @param string $feature
- *        	FEATURE_xx constant for requested feature
+ * @param string $feature FEATURE_xx constant for requested feature
  * @return mixed true if the feature is supported, null if unknown
  */
 function ratingallocate_supports($feature) {
@@ -64,11 +63,13 @@ function ratingallocate_supports($feature) {
             return true;
         case FEATURE_SHOW_DESCRIPTION :
             return true;
-         case FEATURE_BACKUP_MOODLE2:
+        case FEATURE_BACKUP_MOODLE2:
             return true;
-         case FEATURE_COMPLETION_TRACKS_VIEWS:
-             return true;
-        default :
+        case FEATURE_COMPLETION_TRACKS_VIEWS:
+            return true;
+        case FEATURE_GROUPS:
+            return true;
+        default:
             return null;
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -165,11 +165,16 @@ function ratingallocate_delete_instance($id) {
         'ratingallocateid' => $ratingallocate->id
     ));
 
-    $deleteids = $DB->get_records('ratingallocate_choices', array(
+    $deleteids = array_keys($DB->get_records('ratingallocate_choices', array(
         'ratingallocateid' => $ratingallocate->id
-            ), '', 'id');
+            ), '', 'id'));
 
-    $DB->delete_records_list('ratingallocate_ratings', 'choiceid', array_keys($deleteids));
+    list ($insql, $params) = $DB->get_in_or_equal($deleteids);
+
+    $DB->delete_records_select('ratingallocate_group_choices',
+        'choiceid ' . $insql, $params);
+
+    $DB->delete_records_list('ratingallocate_ratings', 'choiceid', $deleteids);
 
     $DB->delete_records('ratingallocate_choices', array(
         'ratingallocateid' => $ratingallocate->id

--- a/lib.php
+++ b/lib.php
@@ -67,8 +67,6 @@ function ratingallocate_supports($feature) {
             return true;
         case FEATURE_COMPLETION_TRACKS_VIEWS:
             return true;
-        case FEATURE_GROUPS:
-            return true;
         default:
             return null;
     }

--- a/locallib.php
+++ b/locallib.php
@@ -379,11 +379,16 @@ class ratingallocate {
 
                 if (!$mform->is_cancelled()) {
                     if ($mform->is_validated()) {
+                        if($data->usegroups) {
+                            $this->update_choice_groups($data->choiceid, $data->groupselector);
+                        }
+
                         // Processing for editor element (FORMAT_HTML is assumed).
                         // Note: No file management implemented at this point.
                         if (is_array($data->explanation)) {
                             $data->explanation = $data->explanation['text'];
                         }
+
                         $this->save_modify_choice_form($data);
 
                         $data = file_postupdate_standard_filemanager($data, 'attachments', $options, $this->context,
@@ -768,6 +773,9 @@ class ratingallocate {
             $choicestatus->publishdate = $this->ratingallocate->publishdate;
             $choicestatus->is_published = $this->ratingallocate->published;
             $choicestatus->available_choices = $this->get_rateable_choices();
+            // Filter choices to display by groups, where 'usegroups' is true.
+            $choicestatus->available_choices = $this->filter_choices_by_groups($choicestatus->available_choices, $USER->id);
+
             $strategysettings = $this->get_strategy_class()->get_static_settingfields();
             if (array_key_exists(ratingallocate\strategy_order\strategy::COUNTOPTIONS, $strategysettings)) {
                 $choicestatus->necessary_choices =
@@ -776,6 +784,8 @@ class ratingallocate {
                 $choicestatus->necessary_choices = 0;
             }
             $choicestatus->own_choices = $this->get_rating_data_for_user($USER->id);
+            // Filter choices to display by groups, where 'usegroups' is true.
+            $choicestatus->own_choices = $this->filter_choices_by_groups($choicestatus->own_choices, $USER->id);
             $choicestatus->allocations = $this->get_allocations_for_user($USER->id);
             $choicestatus->strategy = $this->get_strategy_class();
             $choicestatus->show_distribution_info = has_capability('mod/ratingallocate:start_distribution', $this->context);
@@ -1138,7 +1148,7 @@ class ratingallocate {
      * @return array
      */
     public function get_rating_data_for_user($userid) {
-        $sql = "SELECT c.id as choiceid, c.title, c.explanation, c.ratingallocateid, c.maxsize, r.rating, r.id AS ratingid, r.userid
+        $sql = "SELECT c.id as choiceid, c.title, c.explanation, c.ratingallocateid, c.maxsize, c.usegroups, r.rating, r.id AS ratingid, r.userid
                 FROM {ratingallocate_choices} c
            LEFT JOIN {ratingallocate_ratings} r
                   ON c.id = r.choiceid and r.userid = :userid
@@ -1267,6 +1277,44 @@ class ratingallocate {
             array(this_db\ratingallocate_choices::RATINGALLOCATEID => $this->ratingallocateid,
                 this_db\ratingallocate_choices::ACTIVE => true,
             ), this_db\ratingallocate_choices::TITLE);
+    }
+
+    /**
+     * Filters a list of choice data objects according to a user's group membership.
+     *
+     * @param array $choices An array of objects, keyed by ID. Objects must have a 'usegroups' field.
+     * @param int $userid A user ID.
+     *
+     * @return array A filtered array of choices, keyed by ID.
+     */
+    public function filter_choices_by_groups($choices, $userid) {
+
+        // See all the choices, if you have the capability to modify them.
+        if (has_capability('mod/ratingallocate:modify_choices', $this->context)
+            || has_capability('mod/ratingallocate:export_ratings', $this->context)) {
+            return $choices;
+        }
+
+        $filteredchoices = array();
+
+        // Index 0 for "all groups" without groupings.
+        $usergroupids = groups_get_user_groups($this->course->id, $userid)[0];
+
+        foreach ($choices as $choiceid => $choice) {
+            if ($choice->usegroups) {
+                // Check for overlap between user group and choice group IDs.
+                $choicegroups = $this->get_choice_groups($choiceid);
+                $intersection = array_intersect($usergroupids, array_keys($choicegroups));
+                // Pass if there is an intersection, block otherwise.
+                if (count($intersection)) {
+                    $filteredchoices[$choiceid] = $choice;
+                }
+            } else {
+                $filteredchoices[$choiceid] = $choice;
+            }
+        }
+
+        return $filteredchoices;
     }
 
     /**
@@ -1552,6 +1600,89 @@ class ratingallocate {
     }
 
     /**
+     * Get candidate group selection options for a groupselector form element.
+     *
+     * @param array $grouplist (optional) A list of group records to build mappings from.
+     *
+     * @return array A mapping of group IDs to names.
+     */
+    public function get_group_selections($grouplist=null) {
+        $options = array();
+
+        // Default to all relevant groups for this context.
+        if (!$grouplist) {
+            $grouplist = groups_get_all_groups($this->course->id);
+        }
+
+        foreach ($grouplist as $group) {
+            $options[$group->id] = $group->name;
+        }
+
+        return $options;
+    }
+
+    /**
+     * Returns the groups associated with a ratingallocate choice.
+     *
+     * @param int $choiceid
+     *
+     * @return array A list of group records.
+     */
+    public function get_choice_groups($choiceid) {
+        global $DB;
+
+        $sql = 'SELECT g.*
+        FROM {ratingallocate_group_choices} gc
+        JOIN {groups} g ON gc.groupid=g.id
+        WHERE choiceid=:choiceid';
+
+        $records = $DB->get_records_sql($sql, array('choiceid' => $choiceid));
+        $results = array();
+
+        foreach ($records as $record) {
+            $results[$record->id] = $record;
+        }
+
+        return $results;
+    }
+
+    /**
+     * Update group set for a choice item.
+     *
+     * @param int $choiceid A ratingallocate_choice.
+     * @param array $groupids An array of group IDs to be associated with the choice item.
+     *
+     * @return null
+     */
+    public function update_choice_groups($choiceid, $groupids) {
+        global $DB;
+
+        // Check group IDs against existing choices.
+        $oldgroups = $this->get_choice_groups($choiceid);
+        $oldids = array_keys($oldgroups);
+
+        // Diff gives us all IDs in the first list, but not in the second.
+        $removals = array_values(array_diff($oldids, $groupids));
+        $additions = array_values(array_diff($groupids, $oldids));
+
+        // Add records for new choice group entries.
+        foreach ($additions as $gid) {
+            $record = new stdClass();
+            $record->choiceid = $choiceid;
+            $record->groupid = $gid;
+            $DB->insert_record('ratingallocate_group_choices', $record);
+        }
+
+        // Remove records for obsolete choice group entries.
+        foreach ($removals as $gid) {
+            $DB->delete_records('ratingallocate_group_choices', array(
+                'choiceid' => $choiceid,
+                'groupid' => $gid,
+            ));
+        }
+    }
+
+    /**
      * @return bool true, if all strategy settings are ok.
      */
     public function is_setup_ok() {
@@ -1596,6 +1727,7 @@ class ratingallocate {
  * @property string explanation
  * @property int $maxsize
  * @property bool $active
+ * @property bool $usegroups Whether to restrict the visibility of this choice to the members of specified groups.
  */
 class ratingallocate_choice {
     /** @var stdClass original db record */
@@ -1623,7 +1755,41 @@ class ratingallocate_choice {
     }
 
 }
+/**
+ * Kapselt eine Instanz von ratingallocate_group_choices.
+ * (Encapsulating an instance of ratingallocate_group_choices.)
+ *
+ * @property int $id
+ * @property int $choiceid
+ * @property int $groupid
+ */
+class ratingallocate_group_choices {
+    /** @var stdClass original db record */
+    public $dbrecord;
 
+    /**
+     * Emulates the functionality as if there were explicit records by passing them to the original db record.
+     *
+     * @param string $name
+     * @return mixed
+     */
+    public function __get($name) {
+        return $this->dbrecord->{$name};
+    }
+
+    /**
+     * Emulates the functionality as if there were explicit records by passing them to the original db record.
+     *
+     * @param string $name
+     */
+    public function __set($name, $value) {
+        $this->dbrecord->{$name} = $value;
+    }
+
+    public function __construct($record) {
+        $this->dbrecord = $record;
+    }
+}
 /**
  * Remove all users (or one user) from one group, invented by MxS by copying from group/lib.php
  * because it didn't exist there

--- a/locallib.php
+++ b/locallib.php
@@ -457,6 +457,7 @@ class ratingallocate {
             if ($choiceid) {
                 $choice = $DB->get_record(this_db\ratingallocate_choices::TABLE, array('id' => $choiceid));
                 if ($choice) {
+                    $DB->delete_records(this_db\ratingallocate_group_choices::TABLE, ['choiceid' => $choiceid]);
                     $DB->delete_records(this_db\ratingallocate_choices::TABLE, array('id' => $choiceid));
                     redirect(new moodle_url('/mod/ratingallocate/view.php',
                         array('id' => $this->coursemodule->id, 'action' => ACTION_SHOW_CHOICES)),

--- a/locallib.php
+++ b/locallib.php
@@ -379,10 +379,6 @@ class ratingallocate {
 
                 if (!$mform->is_cancelled()) {
                     if ($mform->is_validated()) {
-                        if($data->usegroups) {
-                            $this->update_choice_groups($data->choiceid, $data->groupselector);
-                        }
-
                         // Processing for editor element (FORMAT_HTML is assumed).
                         // Note: No file management implemented at this point.
                         if (is_array($data->explanation)) {
@@ -395,6 +391,10 @@ class ratingallocate {
                             'mod_ratingallocate', 'choice_attachment', $data->choiceid);
                         $renderer->add_notification(get_string("choice_added_notification", ratingallocate_MOD_NAME),
                         self::NOTIFY_SUCCESS);
+
+                        if ($data->usegroups) {
+                            $this->update_choice_groups($data->choiceid, $data->groupselector);
+                        }
 
                     } else {
                         $output .= $OUTPUT->heading(get_string('edit_choice', ratingallocate_MOD_NAME), 2);

--- a/renderer.php
+++ b/renderer.php
@@ -405,17 +405,19 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
         $table = new \flexible_table('show_ratingallocate_options');
         $table->define_baseurl($PAGE->url);
         if ($choicesmodifiably) {
-            $table->define_columns(array('title', 'explanation', 'maxsize', 'active', 'tools'));
+            $table->define_columns(array('title', 'explanation', 'maxsize', 'active', 'usegroups', 'tools'));
             $table->define_headers(array(get_string('choice_table_title', 'mod_ratingallocate'),
                 get_string('choice_table_explanation', 'mod_ratingallocate'),
                 get_string('choice_table_maxsize', 'mod_ratingallocate'),
                 get_string('choice_table_active', 'mod_ratingallocate'),
+                get_string('choice_table_usegroups', 'mod_ratingallocate'),
                 get_string('choice_table_tools', 'mod_ratingallocate')));
         } else {
-            $table->define_columns(array('title', 'explanation', 'maxsize', 'active'));
+            $table->define_columns(array('title', 'explanation', 'maxsize', 'active', 'usegroups'));
             $table->define_headers(array(get_string('choice_table_title', 'mod_ratingallocate'),
                 get_string('choice_table_explanation', 'mod_ratingallocate'),
                 get_string('choice_table_maxsize', 'mod_ratingallocate'),
+                get_string('choice_table_usegroups', 'mod_ratingallocate'),
                 get_string('choice_table_tools', 'mod_ratingallocate')));
         }
         $table->set_attribute('id', 'mod_ratingallocateshowoptions');
@@ -444,6 +446,12 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
             } else {
                 $row[] = get_string('no');
             }
+            if ($choice->{this_db\ratingallocate_choices::USEGROUPS}) {
+                $row[] = get_string('yes');
+            } else {
+                $row[] = get_string('no');
+            }
+
             if ($choicesmodifiably) {
                 $row[] = $this->render_tools($idx, $choice->{this_db\ratingallocate_choices::ACTIVE},
                     $choice->{this_db\ratingallocate_choices::TITLE});

--- a/strategy/strategy04_points.php
+++ b/strategy/strategy04_points.php
@@ -97,6 +97,8 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
         $mform = $this->_form;
 
         $ratingdata = $this->ratingallocate->get_rating_data_for_user($USER->id);
+        // Filter choices to display by groups, where 'usegroups' is true.
+        $ratingdata = $this->ratingallocate->filter_choices_by_groups($ratingdata, $USER->id);
 
         foreach ($ratingdata as $data) {
             $headerelem = 'head_ratingallocate_' . $data->choiceid;

--- a/strategy/strategy05_order.php
+++ b/strategy/strategy05_order.php
@@ -105,7 +105,9 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
         // Filter choices to display by groups, where 'usegroups' is true.
         $ratingdata = $this->ratingallocate->filter_choices_by_groups($ratingdata, $USER->id);
 
-        $choicecounter = $this->get_strategysetting(strategy::COUNTOPTIONS);
+        // If we have less options because of group restrictions than configured for the strategy,
+        // we have to limit it, because user cannot vote for one option multiple times.
+        $choicecounter = min($this->get_strategysetting(strategy::COUNTOPTIONS), count($ratingdata));
         $choices = array();
 
         foreach ($ratingdata as $data) {

--- a/strategy/strategy05_order.php
+++ b/strategy/strategy05_order.php
@@ -102,6 +102,8 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
         $mform = $this->_form;
 
         $ratingdata = $this->ratingallocate->get_rating_data_for_user($USER->id);
+        // Filter choices to display by groups, where 'usegroups' is true.
+        $ratingdata = $this->ratingallocate->filter_choices_by_groups($ratingdata, $USER->id);
 
         $choicecounter = $this->get_strategysetting(strategy::COUNTOPTIONS);
         $choices = array();

--- a/strategy/strategy06_tickyes.php
+++ b/strategy/strategy06_tickyes.php
@@ -105,6 +105,8 @@ class mod_ratingallocate_view_form extends \ratingallocate_strategyform {
         $mform = $this->_form;
 
         $ratingdata = $this->ratingallocate->get_rating_data_for_user($USER->id);
+        // Filter choices to display by groups, where 'usegroups' is true.
+        $ratingdata = $this->ratingallocate->filter_choices_by_groups($ratingdata, $USER->id);
 
         foreach ($ratingdata as $data) {
             $headerelem = 'head_ratingallocate_' . $data->choiceid;

--- a/strategy/strategy_template_options.php
+++ b/strategy/strategy_template_options.php
@@ -70,6 +70,8 @@ abstract class ratingallocate_options_strategyform extends \ratingallocate_strat
         $mform = $this->_form;
 
         $ratingdata = $this->ratingallocate->get_rating_data_for_user($USER->id);
+        // Filter choices to display by groups, where 'usegroups' is true.
+        $ratingdata = $this->ratingallocate->filter_choices_by_groups($ratingdata, $USER->id);
 
         foreach ($ratingdata as $data) {
             $headerelem = 'head_ratingallocate_' . $data->choiceid;

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -56,12 +56,13 @@ class mod_ratingallocate_generator extends testing_module_generator {
         if ($choicedata === null) {
             $choicedata = self::get_default_choice_data();
         }
+
         $instance = $tc->getDataGenerator()->create_module(ratingallocate_MOD_NAME, $moduledata, $options);
         // Load Ratingallocate Object.
         $ratingallocate = self::get_ratingallocate($instance);
 
         // Create Choices.
-        for ($i = 0; $i < 2; $i++) {
+        for ($i = 0; $i < count($choicedata); $i++) {
             $record = $choicedata[$i];
             $record[this_db\ratingallocate_choices::RATINGALLOCATEID] = $instance->id;
             $ratingallocate->save_modify_choice_form((object) $record);

--- a/tests/mod_generator_test.php
+++ b/tests/mod_generator_test.php
@@ -36,7 +36,7 @@ class mod_ratingallocate_generator_testcase extends advanced_testcase {
         $this->setAdminUser();
 
         $course = $this->getDataGenerator()->create_course();
-        
+
         // There should not be any module for that course first
         $this->assertFalse(
                 $DB->record_exists('ratingallocate', array('course' => $course->id
@@ -85,6 +85,7 @@ class mod_ratingallocate_generator_testcase extends advanced_testcase {
                 'ratingallocateid' => $mod->id,
                 'explanation' => 'Some explanatory text for choice 1',
                 'maxsize' => '10',
+                'usegroups' => '0',
                 'active' => '1'
             ),
             $choice_ids[1] => (object) array(
@@ -93,6 +94,7 @@ class mod_ratingallocate_generator_testcase extends advanced_testcase {
                 'ratingallocateid' => $mod->id,
                 'explanation' => 'Some explanatory text for choice 2',
                 'maxsize' => '5',
+                'usegroups' => '0',
                 'active' => '0'
             )
         );

--- a/tests/mod_ratingallocate_choice_groups_test.php
+++ b/tests/mod_ratingallocate_choice_groups_test.php
@@ -1,0 +1,250 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+require_once(__DIR__ . '/generator/lib.php');
+require_once(__DIR__ . '/../locallib.php');
+
+/**
+ * Tests restriction of choice availability by group membership.
+ *
+ * @package    mod_ratingallocate
+ * @category   test
+ * @group      mod_ratingallocate
+ * @copyright  2021 David Thompson
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mod_ratingallocate_choice_group_testcase extends advanced_testcase {
+
+    /** Helper function - Create a range of choices.
+     *
+     * A thru D use groups, E does not.
+     */
+    private function get_choice_data() {
+        $choices = array();
+
+        $letters = range('A', 'E');
+        foreach ($letters as $key => $letter) {
+            $choice = array(
+                'title' => "Choice $letter",
+                'explanation' => "Explain Choice $letter",
+                'maxsize' => 10,
+                'active' => true,
+            );
+            if ($letter === 'E') {
+                $choice['usegroups'] = false;
+            } else {
+                $choice['usegroups'] = true;
+            }
+            $choices[] = $choice;
+        }
+
+        return $choices;
+    }
+
+    /**
+     * Helper function - Map choice titles to IDs
+     *
+     * @param array $choices
+     *
+     * @return array
+     */
+    private function get_choice_map($choices = null) {
+        if (!$choices) {
+            $choices = $this->ratingallocate->get_rateable_choices();
+        }
+        $choiceidmap = array_flip(array_map(
+            function($a) {
+                return $a->title;
+            },
+            $choices));
+        return $choiceidmap;
+    }
+
+    /**
+     * Helper function - Map group selection names to IDs
+     *
+     * @param array $groups
+     *
+     * @return array
+     */
+    private function get_group_map($groupselections = null) {
+        if (!$groupselections) {
+            $groupselections = $this->ratingallocate->get_group_selections();
+        }
+        $groupidmap = array_flip($groupselections);
+        return $groupidmap;
+    }
+
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        $generator = $this->getDataGenerator();
+
+        $course = $generator->create_course();
+        $this->course = $course;
+        $this->teacher = mod_ratingallocate_generator::create_user_and_enrol($this, $course, true);
+        $this->setUser($this->teacher);
+
+        // Make test groups and enrol students.
+        $green = $generator->create_group(array('name' => 'Green Group', 'courseid' => $course->id));
+        $blue = $generator->create_group(array('name' => 'Blue Group', 'courseid' => $course->id));
+        $red = $generator->create_group(array('name' => 'Red Group', 'courseid' => $course->id));
+
+        $this->student1 = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+        groups_add_member($green, $this->student1);
+        $this->student2 = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+        groups_add_member($blue, $this->student2);
+        $this->student3 = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+        groups_add_member($red, $this->student3);
+        $this->student4 = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+        // No groups for student 4.
+
+        $this->choicedata = $this->get_choice_data();
+        $mod = mod_ratingallocate_generator::create_instance_with_choices($this, array('course' => $course), $this->choicedata);
+        $this->ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $this->teacher);
+    }
+
+
+    protected function tearDown(): void {
+        $this->choicedata = null;
+
+        parent::tearDown();
+    }
+
+    public function test_setup() {
+        $this->resetAfterTest();
+
+        $this->assertEquals(5, count($this->choicedata));
+        $choices = $this->ratingallocate->get_rateable_choices();
+        $this->assertEquals(5, count($choices));
+
+        // Candidates for groupselector match test fixture.
+        $groupselections = $this->ratingallocate->get_group_selections();
+        $this->assertEquals(3, count($groupselections));
+        $this->assertContains('Green Group', $groupselections);
+        $this->assertContains('Blue Group', $groupselections);
+        $this->assertContains('Red Group', $groupselections);
+    }
+
+    public function test_choice_groups() {
+        $this->resetAfterTest();
+
+        // Map choice titles to choice IDs, group names to group IDs.
+        $choices = $this->ratingallocate->get_rateable_choices();
+        $choiceidmap = $this->get_choice_map($choices);
+        $groupselections = $this->ratingallocate->get_group_selections();
+        $groupidmap = $this->get_group_map($groupselections);
+
+        /* Populate choice-group mappings for visibility tests.
+         *
+         * Choice A: Green only
+         * Choice B: Green and Blue
+         * Choice C: Red only
+         * Choice D: 'usegroups' is selected, but no groups; never available to students.
+         * Choice E: 'usegroups' is not selected; always available.
+         */
+        $this->ratingallocate->update_choice_groups($choiceidmap['Choice A'], array(
+            $groupidmap['Green Group']
+        ));
+        $this->ratingallocate->update_choice_groups($choiceidmap['Choice B'], array(
+            $groupidmap['Green Group'], $groupidmap['Blue Group']
+        ));
+        $this->ratingallocate->update_choice_groups($choiceidmap['Choice C'], array(
+            $groupidmap['Red Group']
+        ));
+
+        // Teacher context: all choices shown in teacher view.
+        $basechoices = array_keys($this->ratingallocate->filter_choices_by_groups($choices, $this->teacher->id));
+        $this->assertContains($choiceidmap['Choice A'], $basechoices);
+        $this->assertContains($choiceidmap['Choice B'], $basechoices);
+        $this->assertContains($choiceidmap['Choice C'], $basechoices);
+        $this->assertContains($choiceidmap['Choice D'], $basechoices);
+        $this->assertContains($choiceidmap['Choice E'], $basechoices);
+
+        // Student 1, Green group: A, B, E but not C, D.
+        $this->setUser($this->student1);
+        $s1choices = array_keys($this->ratingallocate->filter_choices_by_groups($choices, $this->student1->id));
+        $this->assertContains($choiceidmap['Choice A'], $s1choices);
+        $this->assertContains($choiceidmap['Choice B'], $s1choices);
+        $this->assertNotContains($choiceidmap['Choice C'], $s1choices);
+        $this->assertNotContains($choiceidmap['Choice D'], $s1choices);
+        $this->assertContains($choiceidmap['Choice E'], $s1choices);
+
+        // Student 2, Blue group: B, E but not A, C, D.
+        $this->setUser($this->student2);
+        $s2choices = array_keys($this->ratingallocate->filter_choices_by_groups($choices, $this->student2->id));
+        $this->assertNotContains($choiceidmap['Choice A'], $s2choices);
+        $this->assertContains($choiceidmap['Choice B'], $s2choices);
+        $this->assertNotContains($choiceidmap['Choice C'], $s2choices);
+        $this->assertNotContains($choiceidmap['Choice D'], $s2choices);
+        $this->assertContains($choiceidmap['Choice E'], $s2choices);
+
+        // Student 3, Red group: C, E but not A, B, D.
+        $this->setUser($this->student3);
+        $s3choices = array_keys($this->ratingallocate->filter_choices_by_groups($choices, $this->student3->id));
+        $this->assertNotContains($choiceidmap['Choice A'], $s3choices);
+        $this->assertNotContains($choiceidmap['Choice B'], $s3choices);
+        $this->assertContains($choiceidmap['Choice C'], $s3choices);
+        $this->assertNotContains($choiceidmap['Choice D'], $s3choices);
+        $this->assertContains($choiceidmap['Choice E'], $s3choices);
+
+        // Student 4, no group: just E.
+        $this->setUser($this->student4);
+        $s4choices = array_keys($this->ratingallocate->filter_choices_by_groups($choices, $this->student4->id));
+        $this->assertNotContains($choiceidmap['Choice A'], $s4choices);
+        $this->assertNotContains($choiceidmap['Choice B'], $s4choices);
+        $this->assertNotContains($choiceidmap['Choice C'], $s4choices);
+        $this->assertNotContains($choiceidmap['Choice D'], $s4choices);
+        $this->assertContains($choiceidmap['Choice E'], $s4choices);
+    }
+
+    public function test_update_choice_groups() {
+        $this->resetAfterTest();
+
+        $choiceidmap = $this->get_choice_map();
+        $groupidmap = $this->get_group_map();
+
+        // Start empty.
+        $groups = $this->ratingallocate->get_choice_groups($choiceidmap['Choice A']);
+        $this->assertTrue(empty($groups));
+
+        // Add one.
+        $this->ratingallocate->update_choice_groups($choiceidmap['Choice A'], array(
+            $groupidmap['Green Group']
+        ));
+        $groups = $this->ratingallocate->get_choice_groups($choiceidmap['Choice A']);
+        $this->assertContains($groupidmap['Green Group'], array_keys($groups));
+
+        // Update to two.
+        $this->ratingallocate->update_choice_groups($choiceidmap['Choice A'], array(
+            $groupidmap['Green Group'], $groupidmap['Blue Group']
+        ));
+        $groups = $this->ratingallocate->get_choice_groups($choiceidmap['Choice A']);
+        $this->assertContains($groupidmap['Green Group'], array_keys($groups));
+        $this->assertContains($groupidmap['Blue Group'], array_keys($groups));
+
+        // Remove one.
+        $this->ratingallocate->update_choice_groups($choiceidmap['Choice A'], array(
+            $groupidmap['Blue Group']
+        ));
+        $groups = $this->ratingallocate->get_choice_groups($choiceidmap['Choice A']);
+        $this->assertNotContains($groupidmap['Green Group'], array_keys($groups));
+        $this->assertContains($groupidmap['Blue Group'], array_keys($groups));
+    }
+
+}

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022041800;        // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2022120100;        // The current module version (Date: YYYYMMDDXX)
 $plugin->requires = 2020061500;         // Requires Moodle 3.9+.
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = 'v4.0-r1';


### PR DESCRIPTION
This PR replaces #242 and adds some commits requested while code review.

@Lauror: One more thing I stumbled over: This PR enables the group mode feature for this activity, so in the activity settings the user now can choose "No groups", "Separate groups" and "Visible groups". However, this option effectively does nothing so the user might wonder what it is for and what he/she has to select to enable a group feature which - like it's currently implemented - is always available anyways (and it does not really match the "group mode" the user knows from most of other moodle activities).

IMO there are 3 options how to deal with that:
1. Keep it as it is to signal the user that there is a group mode. Some documentation would be nice though somewhere to clarify that the group mode selection has no effect at all.
2. The user has to select "Visible groups" or "Separate groups" to enable this feature. If he/she does not, the choice edit form will not offer the possibility to restrict the choices to specific groups.
3. Remove the group mode completely, so the user does not even have the opportunity to select it (just like it is in current master). The restriction of choices to groups is just a feature not related to moodle's group mode feature and always available to the user in the choice form.

What do you think? I personally would tend to option 3.