### PR TITLE
Feat: Distribute users without rating

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -101,6 +101,15 @@ $capabilities = array(
                         'manager' => CAP_ALLOW
                 )
         ),
+        'mod/ratingallocate:distribute_unallocated' => array(
+            'contextlevel' => CONTEXT_MODULE,
+            'riskbitmask' => RISK_PERSONAL,
+            'captype' => 'write',
+            'archetypes' => array(
+                'editingteacher' => CAP_ALLOW,
+                'manager' => CAP_ALLOW
+            )
+        ),
 );
 
 

--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -38,6 +38,7 @@ $string['pluginname'] = 'Fair Allocation';
 $string['groupingname'] = 'Created from Fair Allocation "{$a}"';
 $string['ratingallocate:addinstance'] = 'Add new instance of Fair Allocation';
 $string['ratingallocate:view'] = 'View instances of Fair Allocation';
+$string['ratingallocate:distribute_unallocated'] = 'Ability to distribute unallocated users automatically';
 $string['ratingallocate:give_rating'] = 'Create or edit choice';
 $string['ratingallocate:start_distribution'] = 'Start allocation of users to choices';
 $string['ratingallocate:export_ratings'] = 'Ability to export the user ratings';
@@ -80,6 +81,18 @@ Only users who rated at least one choice and who are not allocated yet are liste
 $string['allocation_manual_explain_all'] = 'Select a choice to be assigned to a user.';
 $string['distribution_algorithm'] = 'Distribution Algorithm';
 $string['distribution_saved'] = 'Distribution saved (in {$a}s).';
+$string['distributeequally'] = 'Distribute unallocated users equally';
+$string['distributefill'] = 'Distribute unallocated users by filling up';
+$string['distribution_description'] = 'Distribution of unallocated users';
+$string['distribution_description_help'] = 'You can choose between two different algorithms to distribute currently unallocated users.<br/>
+ <i>Distribute equally:</i> Users are being distributed equally across the choices regarding the maximum of each choice.<br/>
+ <i>Fill up choices:</i> Every choice is being filled up with users first before filling up the next choice. Choices with
+ least places left are filled up first.<br/><br/>
+ Group restrictions will be respected.';
+$string['distribute_unallocated_fill_confirm'] = 'All currently unallocated users will be distributed to the choices.
+ Each choice will be filled up to its maximum before assigning users to the next choice.';
+$string['distribute_unallocated_equally_confirm'] = 'All currently unallocated users will be distributed to the choices.
+ The choices will be filled up equally, so all of them have about the same amount of places left.';
 $string['no_user_to_allocate'] = 'There is no user you could allocate';
 $string['ratings_table'] = 'Ratings and Allocations';
 $string['ratings_table_sum_allocations'] = 'Number of allocations / Maximum';
@@ -104,6 +117,7 @@ $string['start_distribution'] = 'Run Allocation Algorithm';
 $string['confirm_start_distribution'] =
         'Running the algorithm will delete all existing allocations, if any. Are you sure to continue?';
 $string['unassigned_users'] = 'Unassigned Users';
+$string['unassigned_users_assigned'] = 'Unassigned users have been assigned as good as possible.';
 $string['invalid_dates'] = 'Dates are invalid. Starting date must be before ending date.';
 $string['invalid_publishdate'] = 'Publication date is invalid. Publication date must be after the end of rating.';
 $string['rated'] = 'rated {$a}';

--- a/locallib.php
+++ b/locallib.php
@@ -882,7 +882,7 @@ class ratingallocate {
             if ($choicetoassign === -2) {
                 // This means there are no free places left in any choice for any user, so we can stop the algorithm
                 // as a whole.
-                return;
+                break;
             } else if ($choicetoassign == -1) {
                 // This means that the user could not be assigned (for example due to group restrictions),
                 // so we try the next one.

--- a/locallib.php
+++ b/locallib.php
@@ -1095,8 +1095,7 @@ class ratingallocate {
             case ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY:
             case ACTION_DISTRIBUTE_UNALLOCATED_FILL:
                 $this->distribute_users_without_choice($action);
-                redirect(new moodle_url('/mod/ratingallocate/view.php',
-                            ['id' => $this->coursemodule->id, 'action' => ACTION_NONE]),
+                redirect(new moodle_url('/mod/ratingallocate/view.php', ['id' => $this->coursemodule->id]),
                     get_string('unassigned_users_assigned', ratingallocate_MOD_NAME),
                     null,
                     \core\output\notification::NOTIFY_SUCCESS);

--- a/locallib.php
+++ b/locallib.php
@@ -850,6 +850,10 @@ class ratingallocate {
      * @throws dml_exception
      */
     public function distribute_users_without_choice(string $distributionalgorithm): void {
+        // This could need some extra memory, especially because we are caching some data structures in memory while
+        // running the algorithm.
+        raise_memory_limit(MEMORY_EXTRA);
+        core_php_time_limit::raise();
 
         // This will retrieve a list of users we are trying to assign to choices, sorted from the least group membership count to
         // more group memberships. Users without group memberships will be at the end of the array.

--- a/locallib.php
+++ b/locallib.php
@@ -698,6 +698,9 @@ class ratingallocate {
     public function get_undistributed_users(): array {
         $undistributedusers = [];
         $userswithgroups = $this->get_undistributed_users_with_groupscount();
+        if (empty($userswithgroups)) {
+            return [];
+        }
         for ($i = 1; $i <= max(array_keys($userswithgroups)); $i++) {
             if (empty($userswithgroups[$i])) {
                 continue;
@@ -995,8 +998,10 @@ class ratingallocate {
 
         // Print data and controls for teachers.
         if (has_capability('mod/ratingallocate:start_distribution', $this->context)) {
+            $undistributeduserscount = count($this->get_undistributed_users());
             $output .= $renderer->modify_allocation_group($this->ratingallocateid, $this->coursemodule->id, $status,
-                    (int) $this->ratingallocate->algorithmstatus, (boolean) $this->ratingallocate->runalgorithmbycron);
+                $undistributeduserscount, (int) $this->ratingallocate->algorithmstatus,
+                (boolean) $this->ratingallocate->runalgorithmbycron);
             $output .= $renderer->publish_allocation_group($this->ratingallocateid, $this->coursemodule->id, $status);
             $output .= $renderer->reports_group($this->ratingallocateid, $this->coursemodule->id, $status, $this->context);
         }

--- a/locallib.php
+++ b/locallib.php
@@ -1117,7 +1117,7 @@ class ratingallocate {
             case ACTION_DISTRIBUTE_UNALLOCATED_FILL:
                 $this->distribute_users_without_choice($action);
                 redirect(new moodle_url('/mod/ratingallocate/view.php', ['id' => $this->coursemodule->id]),
-                    get_string('unassigned_users_assigned', ratingallocate_MOD_NAME),
+                    get_string('unassigned_users_assigned', RATINGALLOCATE_MOD_NAME),
                     null,
                     \core\output\notification::NOTIFY_SUCCESS);
                 break;

--- a/locallib.php
+++ b/locallib.php
@@ -811,7 +811,11 @@ class ratingallocate {
         $choicessortedwithgroupscount = [];
         $choicessorted = [];
         foreach (array_keys($possiblechoices) as $choiceid) {
-            $choicessortedwithgroupscount[count($this->get_choice_groups($choiceid))][] = $choiceid;
+            $choice = $DB->get_record('ratingallocate_choices', ['id' => $choiceid]);
+            // In case group restrictions are disabled for a choice that choice could still could have groups assigned.
+            // However, we need to treat them like they do not have any groups.
+            $groupscount = empty($choice->usegroups) ? 0 : count($this->get_choice_groups($choiceid));
+            $choicessortedwithgroupscount[$groupscount][] = $choiceid;
         }
         foreach ($choicessortedwithgroupscount as &$choiceswithcertaingroupcount) {
             usort($choiceswithcertaingroupcount, function($a, $b) use ($placesleft) {

--- a/locallib.php
+++ b/locallib.php
@@ -88,6 +88,8 @@ define('ACTION_DISABLE_CHOICE', 'disable_choice');
 define('ACTION_DELETE_CHOICE', 'delete_choice');
 define('ACTION_START_DISTRIBUTION', 'start_distribution');
 define('ACTION_MANUAL_ALLOCATION', 'manual_allocation');
+define('ACTION_DISTRIBUTE_UNALLOCATED_FILL', 'distribute_unallocated_fill');
+define('ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY', 'distribute_unallocated_equally');
 define('ACTION_PUBLISH_ALLOCATIONS', 'publish_allocations'); // Make them displayable for the users.
 define('ACTION_SOLVE_LP_SOLVE', 'solve_lp_solve'); // Instead of only generating the mps-file, let it solve.
 define('ACTION_SHOW_RATINGS_AND_ALLOCATION_TABLE', 'show_ratings_and_allocation_table');
@@ -177,7 +179,8 @@ class ratingallocate {
      * Returns all users enrolled in the course the ratingallocate is in
      */
     public function get_raters_in_course() {
-        $raters = get_enrolled_users($this->context, 'mod/ratingallocate:give_rating');
+        // Pulling this sorted from the database improves performance of distribution of unallocated users by a lot.
+        $raters = get_enrolled_users($this->context, 'mod/ratingallocate:give_rating', 0, 'u.*', 'id');
         return $raters;
     }
 
@@ -628,6 +631,248 @@ class ratingallocate {
         return $output;
     }
 
+    /**
+     * Retrieve all used groups in rateable choices.
+     *
+     * @return array of group ids used in rateable choices
+     */
+    public function get_all_groups_of_choices(): array {
+        $rateablechoiceswithgrouprestrictions = array_filter($this->get_rateable_choices(),
+                fn($choice) => !empty($choice->usegroups) && !empty($this->get_choice_groups($choice->id)));
+        $rateablechoiceids = array_map(fn($choice) => $choice->id, $rateablechoiceswithgrouprestrictions);
+        $groupids = [];
+        foreach ($rateablechoiceids as $choiceid) {
+            $groupids = array_merge($groupids, array_map(fn($group) => $group->id, $this->get_choice_groups($choiceid)));
+        }
+        return array_unique($groupids);
+    }
+
+    /**
+     * Helper method returning an array of groupids belonging to the groups the user is member in.
+     *
+     * If the user is not a member of any group an empty array is being returned. Only group ids of groups defined in the
+     * choices restrictions are being considered here.
+     *
+     * @param int $userid the id of the user we want to get the group ids he/she belongs to
+     * @return array of group ids the user belongs to, not including groups which are not specified in at least one of the choices'
+     *  group restrictions
+     */
+    public function get_user_groupids(int $userid): array {
+        $groups = groups_get_user_groups($this->ratingallocate->course, $userid)[0];
+        if (empty($groups)) {
+            return [];
+        } else {
+            return array_filter($groups, fn($group) => in_array($group, $this->get_all_groups_of_choices()));
+        }
+    }
+
+    /**
+     * Helper function to retrieve undistributed users.
+     *
+     * This function returns an associative array [groupcount => [ users ]], groupcount meaning the amount of groups (used in
+     *  ratingallocate choices) the users are member of.
+     *
+     * @return array Associative array [groupcount => [ users ]]
+     */
+    private function get_undistributed_users_with_groupscount(): array {
+        $cachedallocations = $this->get_allocations();
+        $raters = $this->get_raters_in_course();
+        $undistributedusers = array_map(fn($user) => $user->id, array_values(array_filter($raters,
+            fn($user) => !in_array($user->id, array_keys($cachedallocations)))));
+
+        $undistributeduserswithgroups = [];
+        foreach ($undistributedusers as $user) {
+            $undistributeduserswithgroups[count($this->get_user_groupids($user))][] = $user;
+        }
+        return $undistributeduserswithgroups;
+    }
+
+    /**
+     * Returns an array of all userids of users which do not have an allocation (yet).
+     *
+     * This array will be sorted: Users with fewer memberships in groups used in the choices will come first. Exception:
+     * Users without group membership (groups count 0) are at the end of the array.
+     *
+     * @return array Array of user ids not having an allocation
+     */
+    public function get_undistributed_users(): array {
+        $undistributedusers = [];
+        $userswithgroups = $this->get_undistributed_users_with_groupscount();
+        for ($i = 1; $i <= max(array_keys($userswithgroups)); $i++) {
+            if (empty($userswithgroups[$i])) {
+                continue;
+            }
+            $undistributedusers = array_merge($undistributedusers, $userswithgroups[$i]);
+        }
+        if (!empty($userswithgroups[0])) {
+            $undistributedusers = array_merge($undistributedusers, $userswithgroups[0]);
+        }
+        return $undistributedusers;
+    }
+
+    /**
+     * Function to retrieve the next choice which an undistributed user should be assigned to.
+     *
+     * @param string $distributionalgorithm the algorithm which should be applied to search for the next choice
+     * @param int $userid the userid of the user for which the next choice should be retrieved
+     * @return int $choiceid id of the choice the given user should be assigned to
+     * @throws dml_exception
+     */
+    public function get_next_choice_to_assign_user(string $distributionalgorithm, int $userid): int {
+        global $DB;
+
+        $placesleft = [];
+        // Due to performance reasons we need to save some database query results to avoid multiple inefficient queries.
+        $cachedusergroupids = $this->get_user_groupids($userid);
+        $cachedundistributedusers = $this->get_undistributed_users();
+        $cachedallocations = $this->get_allocations();
+        $cachedchoices = [];
+        foreach ($this->get_rateable_choices() as $choice) {
+            $cachedchoices[$choice->id] = $choice;
+            $placesleft[$choice->id] = $choice->maxsize -
+                count(array_filter($cachedallocations, fn($allocation) => $allocation->choiceid == $choice->id));
+        }
+
+        // We have to remove the choices which are already maxed out.
+        $placesleft = array_filter($placesleft, fn($numberoffreeplaces) => $numberoffreeplaces != 0);
+
+        // Filter choices the user cannot be assigned to.
+        foreach (array_keys($placesleft) as $choiceid) {
+            $choice = $DB->get_record('ratingallocate_choices', ['id' => $choiceid]);
+            if (empty($choice->usegroups)) {
+                // If we have a group without group restrictions it will always be available.
+                continue;
+            }
+            $choicegroups = $this->get_choice_groups($choiceid);
+            if (empty($choicegroups)) {
+                // If we have a group with group restrictions enabled, but without groups defined, no user
+                // can ever be assigned, so remove it.
+                unset($placesleft[$choiceid]);
+                continue;
+            }
+            // So only choices with 'proper' group restrictions are left now.
+            $groupidsofcurrentchoice = array_map(fn($group) => $group->id, $choicegroups);
+            $intersectinggroupids = array_intersect($cachedusergroupids, $groupidsofcurrentchoice);
+            if (empty($intersectinggroupids)) {
+                // If the user is not in one of the groups of the current choice, we remove the choice from possibles choices.
+                unset($placesleft[$choiceid]);
+            }
+        }
+
+        // At this point $placesleft only contains choices the user can be assigned to.
+        if (empty($placesleft)) {
+            // If we have no choice to assign, we return -1 to signal the algorithm that we cannot assign the user.
+            return -1;
+        }
+
+        // We now have to decide which choice id will be returned as the one the user will be assigned to.
+        // In case of "equal distribution" we have to fake the amount of available places first.
+        if ($distributionalgorithm == ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY) {
+            $userstodistributecount = count($cachedundistributedusers);
+            $freeplacescount = array_reduce($placesleft, fn($a, $b) => $a + $b);
+
+            $freeplacesoverhang = $freeplacescount - $userstodistributecount;
+
+            if ($freeplacesoverhang > 0) {
+                // Only if there are more free places than users to distribute, we want to distribute "equally".
+                // Choices with more places left should be targeted first when reducing places left.
+                arsort($placesleft);
+                $i = 0;
+                $choicesmaxed = [];
+                // We now lower each count of available places in each choice for every additional place that we have altogether
+                // than users to still distribute.
+                while ($freeplacesoverhang > 0 && count(array_unique($choicesmaxed)) < count($placesleft)) {
+                    // Second condition means that we will stop if we failed trying to reduce *every* choice.
+                    $nextchoiceid = array_keys($placesleft)[$i];
+                    if ($placesleft[$nextchoiceid] > 0) {
+                        // If we can still lower it, we do it.
+                        $placesleft[$nextchoiceid] = $placesleft[$nextchoiceid] - 1;
+                        $freeplacesoverhang--;
+                    } else {
+                        // If we cannot lower the places left anymore for this choice, we track that and will try to lower the
+                        // available places for the next one instead.
+                        $choicesmaxed[] = $nextchoiceid;
+                    }
+                    $i++;
+                    // We are iterating over all the choices constantly and try to reduce the available places.
+                    $i = $i % count($placesleft);
+                }
+                // We recalculated the left places for each choice, so we have to remove the choices which are now maxed out.
+                $placesleft = array_filter($placesleft, fn($numberoffreeplaces) => $numberoffreeplaces != 0);
+            }
+        }
+
+        // From here on it's just the algorithm 'distribute by filling up'.
+        $possiblechoices = $placesleft;
+
+        $choicessortedwithgroupscount = [];
+        $choicessorted = [];
+        foreach (array_keys($possiblechoices) as $choiceid) {
+            $choicessortedwithgroupscount[count($this->get_choice_groups($choiceid))][] = $choiceid;
+        }
+        foreach ($choicessortedwithgroupscount as &$choiceswithcertaingroupcount) {
+            usort($choiceswithcertaingroupcount, function($a, $b) use ($placesleft) {
+                // Choices with the same amount of groups are sorted according the count of left places: fewer places first.
+                return $placesleft[$a] - $placesleft[$b];
+            });
+        }
+        for ($i = 1; $i <= max(array_keys($choicessortedwithgroupscount)); $i++) {
+            if (empty($choicessortedwithgroupscount[$i])) {
+                continue;
+            }
+            $choicessorted = array_merge($choicessorted, $choicessortedwithgroupscount[$i]);
+        }
+        if (!empty($choicessortedwithgroupscount[0])) {
+            $choicessorted = array_merge($choicessorted, $choicessortedwithgroupscount[0]);
+        }
+
+        // This is kind of a dilemma. We want the choices to be filled up beginning at the one with the least places left to fill it
+        // up as quickly as possible.
+        // However, in case of group restrictions this will lead to problems as we are assigning users which have to be assigned to
+        // specific choices (because all others cannot be assigned to it). So in the end these choices will not be available when
+        // we arrive at the choice with the group restrictions.
+        // Therefore, we are first filling up choices with group restrictions first (beginning at choices with fewer groups). Only
+        // in case we have the same amount of groups for two choices or we have no group restrictions at all we pick choices with
+        // fewer places left first (see foreach loop with usort a few lines above).
+
+        return !empty($choicessorted) ? array_shift($choicessorted) : -1;
+    }
+
+    /**
+     * Try to distribute all currently unallocated users.
+     *
+     * @param string $distributionalgorithm the distributionalgorithm which should be used, you can choose between
+     *  ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY and ACTION_DISTRIBUTE_UNALLOCATED_FILL
+     * @return void
+     * @throws dml_exception
+     */
+    public function distribute_users_without_choice(string $distributionalgorithm): void {
+
+        // This will retrieve a list of users we are trying to assign to choices, sorted from the least group membership count to
+        // more group memberships. Users without group memberships will be at the end of the array.
+        $possibleusers = $this->get_undistributed_users();
+
+        $transaction = $this->db->start_delegated_transaction();
+
+        $usertoassign = array_shift($possibleusers);
+        // As long as we have a user to assign, we try to assign him.
+        while ($usertoassign != null) {
+
+            // Calculate the choice to assign the user to depending on the given algorithm.
+            $choicetoassign = $this->get_next_choice_to_assign_user($distributionalgorithm, $usertoassign);
+            if ($choicetoassign == -1) {
+                // If the function returns -1 that means that the user could not be assigned, so we try the next one.
+                $usertoassign = array_shift($possibleusers);
+                continue;
+            }
+            $this->add_allocation($choicetoassign, $usertoassign);
+            $usertoassign = array_shift($possibleusers);
+        }
+        // At this point we tried to assign all the users. It is possible that users remain undistributed, though.
+
+        $transaction->allow_commit();
+    }
+
     private function process_action_show_ratings_and_alloc_table() {
         $output = '';
         // Print ratings table.
@@ -840,6 +1085,16 @@ class ratingallocate {
 
             case ACTION_MANUAL_ALLOCATION:
                 $output .= $this->process_action_manual_allocation();
+                break;
+
+            case ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY:
+            case ACTION_DISTRIBUTE_UNALLOCATED_FILL:
+                $this->distribute_users_without_choice($action);
+                redirect(new moodle_url('/mod/ratingallocate/view.php',
+                            ['id' => $this->coursemodule->id, 'action' => ACTION_NONE]),
+                    get_string('unassigned_users_assigned', ratingallocate_MOD_NAME),
+                    null,
+                    \core\output\notification::NOTIFY_SUCCESS);
                 break;
 
             case ACTION_SHOW_RATINGS_AND_ALLOCATION_TABLE:
@@ -1531,6 +1786,7 @@ class ratingallocate {
 
     /**
      * Remove all allocations of a user.
+     *
      * @param int $userid id of the user.
      */
     public function remove_allocations($userid) {

--- a/renderer.php
+++ b/renderer.php
@@ -288,7 +288,8 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
     /**
      * Output the ratingallocate modfify allocation
      */
-    public function modify_allocation_group($ratingallocateid, $coursemoduleid, $status, $algorithmstatus, $runalgorithmbycron) {
+    public function modify_allocation_group($ratingallocateid, $coursemoduleid,
+            $status, $undistributeduserscount, $algorithmstatus, $runalgorithmbycron) {
         $output = '';
         $output .= $this->heading(get_string('modify_allocation_group', RATINGALLOCATE_MOD_NAME), 2);
         $output .= $this->box_start();
@@ -327,7 +328,7 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
             $button = new single_button($distributeunallocatedurl,
                 get_string('distributeequally', ratingallocate_MOD_NAME), 'get');
             // Enable only if the instance is ready and the algorithm may run manually
-            $button->disabled = !($ratingover);
+            $button->disabled = !($ratingover) || $undistributeduserscount === 0;
             $button->add_action(new confirm_action(
                 get_string('distribute_unallocated_equally_confirm',ratingallocate_MOD_NAME)));
 
@@ -336,8 +337,8 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
             $distributeunallocatedurl = new moodle_url($PAGE->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_FILL));
             $button = new single_button($distributeunallocatedurl,
                 get_string('distributefill', ratingallocate_MOD_NAME), 'get');
-            // Enable only if the instance is ready and the algorithm may run manually
-            $button->disabled = !($ratingover);
+            // Enable only if the instance is ready, there are users to distribute and the algorithm may run manually
+            $button->disabled = !($ratingover) || $undistributeduserscount === 0;
             $button->add_action(new confirm_action(
                 get_string('distribute_unallocated_fill_confirm', ratingallocate_MOD_NAME)));
 

--- a/renderer.php
+++ b/renderer.php
@@ -290,8 +290,6 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
      */
     public function modify_allocation_group($ratingallocateid, $coursemoduleid,
             $status, $undistributeduserscount, $algorithmstatus, $runalgorithmbycron) {
-        global $PAGE;
-
         $output = '';
         $output .= $this->heading(get_string('modify_allocation_group', RATINGALLOCATE_MOD_NAME), 2);
         $output .= $this->box_start();
@@ -321,11 +319,10 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
                 'action' => ACTION_MANUAL_ALLOCATION)), get_string('manual_allocation_form', RATINGALLOCATE_MOD_NAME), 'get',
                 array('disabled' => !$ratingover));
 
-
         if (has_capability('mod/ratingallocate:distribute_unallocated', context_module::instance($coursemoduleid))) {
             $output .= html_writer::start_div('ratingallocate_distribute_unallocated');
 
-            $distributeunallocatedurl = new moodle_url($PAGE->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY));
+            $distributeunallocatedurl = new moodle_url($this->page->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY));
 
             $button = new single_button($distributeunallocatedurl,
                 get_string('distributeequally', RATINGALLOCATE_MOD_NAME), 'get');
@@ -336,7 +333,7 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
 
             $output .= $this->render($button);
 
-            $distributeunallocatedurl = new moodle_url($PAGE->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_FILL));
+            $distributeunallocatedurl = new moodle_url($this->page->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_FILL));
             $button = new single_button($distributeunallocatedurl,
                 get_string('distributefill', RATINGALLOCATE_MOD_NAME), 'get');
             // Enable only if the instance is ready, there are users to distribute and the algorithm may run manually

--- a/renderer.php
+++ b/renderer.php
@@ -326,17 +326,17 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
 
             $button = new single_button($distributeunallocatedurl,
                 get_string('distributeequally', RATINGALLOCATE_MOD_NAME), 'get');
-            // Enable only if the instance is ready and the algorithm may run manually
+            // Enable only if the instance is ready and the algorithm may run manually.
             $button->disabled = !($ratingover) || $undistributeduserscount === 0;
             $button->add_action(new confirm_action(
-                get_string('distribute_unallocated_equally_confirm',RATINGALLOCATE_MOD_NAME)));
+                get_string('distribute_unallocated_equally_confirm', RATINGALLOCATE_MOD_NAME)));
 
             $output .= $this->render($button);
 
             $distributeunallocatedurl = new moodle_url($this->page->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_FILL));
             $button = new single_button($distributeunallocatedurl,
                 get_string('distributefill', RATINGALLOCATE_MOD_NAME), 'get');
-            // Enable only if the instance is ready, there are users to distribute and the algorithm may run manually
+            // Enable only if the instance is ready, there are users to distribute and the algorithm may run manually.
             $button->disabled = !($ratingover) || $undistributeduserscount === 0;
             $button->add_action(new confirm_action(
                 get_string('distribute_unallocated_fill_confirm', RATINGALLOCATE_MOD_NAME)));

--- a/renderer.php
+++ b/renderer.php
@@ -318,6 +318,34 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
                 'action' => ACTION_MANUAL_ALLOCATION)), get_string('manual_allocation_form', RATINGALLOCATE_MOD_NAME), 'get',
                 array('disabled' => !$ratingover));
 
+
+        if (has_capability('mod/ratingallocate:distribute_unallocated', context_module::instance($coursemoduleid))) {
+            $output .= html_writer::start_div('ratingallocate_distribute_unallocated');
+
+            $distributeunallocatedurl = new moodle_url($PAGE->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY));
+
+            $button = new single_button($distributeunallocatedurl,
+                get_string('distributeequally', ratingallocate_MOD_NAME), 'get');
+            // Enable only if the instance is ready and the algorithm may run manually
+            $button->disabled = !($ratingover);
+            $button->add_action(new confirm_action(
+                get_string('distribute_unallocated_equally_confirm',ratingallocate_MOD_NAME)));
+
+            $output .= $this->render($button);
+
+            $distributeunallocatedurl = new moodle_url($PAGE->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_FILL));
+            $button = new single_button($distributeunallocatedurl,
+                get_string('distributefill', ratingallocate_MOD_NAME), 'get');
+            // Enable only if the instance is ready and the algorithm may run manually
+            $button->disabled = !($ratingover);
+            $button->add_action(new confirm_action(
+                get_string('distribute_unallocated_fill_confirm', ratingallocate_MOD_NAME)));
+
+            $output .= $this->render($button);
+            $output .= $this->help_icon('distribution_description', ratingallocate_MOD_NAME);
+            $output .= html_writer::end_div();
+        }
+
         $output .= $this->box_end();
         return $output;
     }

--- a/renderer.php
+++ b/renderer.php
@@ -290,6 +290,8 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
      */
     public function modify_allocation_group($ratingallocateid, $coursemoduleid,
             $status, $undistributeduserscount, $algorithmstatus, $runalgorithmbycron) {
+        global $PAGE;
+
         $output = '';
         $output .= $this->heading(get_string('modify_allocation_group', RATINGALLOCATE_MOD_NAME), 2);
         $output .= $this->box_start();
@@ -326,24 +328,24 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
             $distributeunallocatedurl = new moodle_url($PAGE->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY));
 
             $button = new single_button($distributeunallocatedurl,
-                get_string('distributeequally', ratingallocate_MOD_NAME), 'get');
+                get_string('distributeequally', RATINGALLOCATE_MOD_NAME), 'get');
             // Enable only if the instance is ready and the algorithm may run manually
             $button->disabled = !($ratingover) || $undistributeduserscount === 0;
             $button->add_action(new confirm_action(
-                get_string('distribute_unallocated_equally_confirm',ratingallocate_MOD_NAME)));
+                get_string('distribute_unallocated_equally_confirm',RATINGALLOCATE_MOD_NAME)));
 
             $output .= $this->render($button);
 
             $distributeunallocatedurl = new moodle_url($PAGE->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_FILL));
             $button = new single_button($distributeunallocatedurl,
-                get_string('distributefill', ratingallocate_MOD_NAME), 'get');
+                get_string('distributefill', RATINGALLOCATE_MOD_NAME), 'get');
             // Enable only if the instance is ready, there are users to distribute and the algorithm may run manually
             $button->disabled = !($ratingover) || $undistributeduserscount === 0;
             $button->add_action(new confirm_action(
-                get_string('distribute_unallocated_fill_confirm', ratingallocate_MOD_NAME)));
+                get_string('distribute_unallocated_fill_confirm', RATINGALLOCATE_MOD_NAME)));
 
             $output .= $this->render($button);
-            $output .= $this->help_icon('distribution_description', ratingallocate_MOD_NAME);
+            $output .= $this->help_icon('distribution_description', RATINGALLOCATE_MOD_NAME);
             $output .= html_writer::end_div();
         }
 

--- a/styles.css
+++ b/styles.css
@@ -62,3 +62,7 @@
 .path-mod-ratingallocate .mod-ratingallocate-choice-maxno {
     text-align: right;
 }
+
+.ratingallocate_distribute_unallocated {
+    margin: 1em 1em 0 0;
+}

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -128,6 +128,19 @@ class locallib_test extends advanced_testcase {
         $this->assertContains($student3->id, array_map($mapuserid, $alloc2));
         // Assert, that student 4 was allocated to choice 2.
         $this->assertContains($student4->id, array_map($mapuserid, $alloc2));
+
+        // We now unenrol a user and make sure he will not be considered in distribution.
+        $manualenrolplugin = enrol_get_plugin('manual');
+        $enrolinstance = array_values(
+            array_filter(enrol_get_instances($course->id, true), fn($instance) => $instance->enrol == "manual"))[0];
+
+        $manualenrolplugin->unenrol_user($enrolinstance, $student3->id);
+        // Re-distributing will first clear all allocations, so afterwards we will see if the unenrolled user has been considered.
+        $ratingallocate->distrubute_choices();
+
+        $numallocations = $DB->count_records(this_db\ratingallocate_allocations::TABLE);
+        $this->assertEquals(3, $numallocations, 'There should be only 3 allocations, because we unenrolled '
+            . 'a student, so this one should not have been distributed.');
     }
 
     private static function filter_allocations_by_choice($allocations, $choiceid) {

--- a/tests/mod_ratingallocate_allocate_unrated_test.php
+++ b/tests/mod_ratingallocate_allocate_unrated_test.php
@@ -1,0 +1,592 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+require_once(__DIR__ . '/generator/lib.php');
+require_once(__DIR__ . '/../locallib.php');
+
+/**
+ * Tests distribution of users who did not rate.
+ *
+ * @package    mod_ratingallocate
+ * @category   test
+ * @group      mod_ratingallocate
+ * @copyright  2022 ISB Bayern
+ * @author     Philipp Memmel
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mod_ratingallocate_allocate_unrated_test extends advanced_testcase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+
+        $generator = $this->getDataGenerator();
+
+        $course = $generator->create_course();
+        $this->course = $course;
+        $this->teacher = mod_ratingallocate_generator::create_user_and_enrol($this, $course, true);
+        $this->setUser($this->teacher);
+
+        // Make test groups and enrol students.
+        $this->green = $generator->create_group(['name' => 'Green Group', 'courseid' => $course->id]);
+        $this->blue = $generator->create_group(['name' => 'Blue Group', 'courseid' => $course->id]);
+        $this->red = $generator->create_group(['name' => 'Red Group', 'courseid' => $course->id]);
+
+        // We need a few more students to see if distribution is ok.
+        for ($i = 0; $i < 10; $i++) {
+            $this->studentsgreen[] = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+            groups_add_member($this->green, $this->studentsgreen[$i]);
+            $this->studentsblue[] = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+            groups_add_member($this->blue, $this->studentsblue[$i]);
+            $this->studentsred[] = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+            groups_add_member($this->red, $this->studentsred[$i]);
+            $this->studentsnogroup[] = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+        }
+    }
+
+    /**
+     * Asserts that there is no allocation violating the group restrictions. This should be called after the algorithms have been
+     * run to assert that the algorithm did respect the group restrictions when allocating.
+     *
+     * @return void
+     */
+    private function test_group_memberships(): void {
+        foreach ([$this->studentsred, $this->studentsblue, $this->studentsgreen] as $students) {
+            foreach ($students as $student) {
+                $allocations = $this->ratingallocate->get_allocations_for_user($student->id);
+                foreach ($allocations as $allocation) {
+                    if (empty(array_filter($this->ratingallocate->get_rateable_choices(),
+                        fn($choice) => $choice->id === $allocation->choiceid)[0]->usegroups)) {
+                        // If the choice has no group restrictions active we do not have to assert anything.
+                        continue;
+                    }
+                    $choicegroups =
+                        array_map(fn($group) => $group->id, $this->ratingallocate->get_choice_groups($allocation->choiceid));
+                    $usergroups = groups_get_user_groups($this->course->id, $student->id)[0];
+                    $this->assertFalse(empty(array_intersect($choicegroups, $usergroups)));
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests the helper function to retrieve all used groups by the choices.
+     *
+     * @covers ratingallocate::get_all_groups_of_choices
+     * @return void
+     */
+    public function test_get_all_groups_of_choices(): void {
+        $choices = [];
+
+        $letters = range('A', 'E');
+        foreach ($letters as $letter) {
+            $choice = [
+                'title' => "$letter",
+                'explanation' => "Explain Choice $letter",
+                'maxsize' => 8,
+                'active' => true,
+            ];
+
+            if ($letter === 'C' || $letter === 'D' || $letter === 'E') {
+                $choice['usegroups'] = true;
+            } else {
+                $choice['usegroups'] = false;
+            }
+            $choices[] = $choice;
+        }
+
+        $mod = mod_ratingallocate_generator::create_instance_with_choices($this,
+            ['course' => $this->course,
+                'strategyopt' => ['countoptions' => 3],
+                'strategy' => 'strategy_order'],
+            $choices);
+        $this->ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $this->teacher);
+
+        // Assign blue group to choice D, green group to choice E.
+        $this->ratingallocate->update_choice_groups($this->get_choice_id_by_title('D'), [$this->blue->id]);
+        $this->ratingallocate->update_choice_groups($this->get_choice_id_by_title('E'), [$this->green->id]);
+        // Choice C has group restrictions enabled, but no groups defined, so should be ignored.
+        // Choice B has no group restrictions enabled, so its group 'red' should be ignored.
+        $this->ratingallocate->update_choice_groups($this->get_choice_id_by_title('B'), [$this->red->id]);
+
+        $this->assertCount(2, $this->ratingallocate->get_all_groups_of_choices());
+        $this->assertTrue(in_array($this->blue->id, $this->ratingallocate->get_all_groups_of_choices()));
+        $this->assertTrue(in_array($this->green->id, $this->ratingallocate->get_all_groups_of_choices()));
+        $this->assertFalse(in_array($this->red->id, $this->ratingallocate->get_all_groups_of_choices()));
+    }
+
+    public function test_get_user_groupids(): void {
+
+        $choices = [];
+
+        $letters = range('A', 'E');
+        foreach ($letters as $letter) {
+            $choice = [
+                'title' => "$letter",
+                'explanation' => "Explain Choice $letter",
+                'maxsize' => 8,
+                'active' => true,
+            ];
+
+            if ($letter === 'D' || $letter === 'E') {
+                $choice['usegroups'] = true;
+            } else {
+                $choice['usegroups'] = false;
+            }
+            $choices[] = $choice;
+        }
+
+        $mod = mod_ratingallocate_generator::create_instance_with_choices($this,
+            ['course' => $this->course,
+                'strategyopt' => ['countoptions' => 3],
+                'strategy' => 'strategy_order'],
+            $choices);
+        $this->ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $this->teacher);
+
+        // Pick random red group user, also assign to group blue and green.
+        $studentredbluegreen = $this->studentsred[5];
+        groups_add_member($this->green, $studentredbluegreen);
+        groups_add_member($this->blue, $studentredbluegreen);
+
+        // Pick another different random red group user, also to group blue.
+        $studentredblue = $this->studentsred[7];
+        groups_add_member($this->blue, $studentredblue);
+
+        $this->assertCount(0, $this->ratingallocate->get_user_groupids($studentredblue->id));
+        $this->assertCount(0, $this->ratingallocate->get_user_groupids($studentredbluegreen->id));
+
+        $this->ratingallocate->update_choice_groups($this->get_choice_id_by_title('E'), [$this->red->id, $this->blue->id]);
+        $this->assertCount(2, $this->ratingallocate->get_user_groupids($studentredblue->id));
+        $this->assertCount(2, $this->ratingallocate->get_user_groupids($studentredbluegreen->id));
+
+        $this->ratingallocate->update_choice_groups($this->get_choice_id_by_title('D'), [$this->green->id]);
+        $this->assertCount(2, $this->ratingallocate->get_user_groupids($studentredblue->id));
+        $this->assertCount(3, $this->ratingallocate->get_user_groupids($studentredbluegreen->id));
+    }
+
+    /**
+     * Tests the method retrieving all currently undistributed users.
+     *
+     * The method will sort the users depending on the amount of groups used in the choices' group restrictions.
+     *
+     * @covers ratingallocate::get_undistributed_users_with_groupscount
+     * @covers ratingallocate::get_undistributed_users
+     * @return void
+     * @throws coding_exception
+     */
+    public function test_get_undistributed_users(): void {
+        $choices = [];
+
+        $letters = range('A', 'E');
+        foreach ($letters as $letter) {
+            $choice = [
+                'title' => "$letter",
+                'explanation' => "Explain Choice $letter",
+                'maxsize' => 8,
+                'active' => true,
+            ];
+
+            if ($letter === 'D' || $letter === 'E') {
+                $choice['usegroups'] = true;
+            } else {
+                $choice['usegroups'] = false;
+            }
+            $choices[] = $choice;
+        }
+
+        $mod = mod_ratingallocate_generator::create_instance_with_choices($this,
+            ['course' => $this->course,
+                'strategyopt' => ['countoptions' => 3],
+                'strategy' => 'strategy_order'],
+            $choices);
+        $this->ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $this->teacher);
+
+        // Assign blue and green group to choice D, red group to choice E.
+        $this->ratingallocate->update_choice_groups($this->get_choice_id_by_title('D'),
+            [$this->blue->id, $this->green->id, $this->red->id]);
+        $this->ratingallocate->update_choice_groups($this->get_choice_id_by_title('E'), [$this->red->id]);
+
+        $studentonetwogroups = $this->studentsred[7];
+        groups_add_member($this->blue->id, $studentonetwogroups->id);
+        $studenttwotwogroups = $this->studentsred[1];
+        groups_add_member($this->blue->id, $studenttwotwogroups->id);
+        $studentthreetwogroups = $this->studentsred[4];
+        groups_add_member($this->blue->id, $studentthreetwogroups->id);
+
+        $studentonethreegroups = $this->studentsred[2];
+        groups_add_member($this->blue->id, $studentonethreegroups->id);
+        groups_add_member($this->green->id, $studentonethreegroups->id);
+        $studenttwothreegroups = $this->studentsred[3];
+        groups_add_member($this->blue->id, $studenttwothreegroups->id);
+        groups_add_member($this->green->id, $studenttwothreegroups->id);
+
+        // We now have:
+        // 10 students without a group
+        // 10 students with only group green, 10 students with only group blue
+        // 5 students with only group red
+        // 3 students with two groups (red, blue)
+        // 2 students with three groups (red, blue, green)
+        // Expected order should be: 25 students with one group, 3 students with two groups,
+        //   2 students with three groups, 10 students without group.
+
+        $users = $this->ratingallocate->get_undistributed_users();
+        $i = 0;
+        foreach ($users as $user) {
+            $groupscount = count($this->ratingallocate->get_user_groupids($user));
+            if ($i < 25) {
+                $this->assertEquals(1, $groupscount);
+            } else if ($i >= 25 && $i < 28) {
+                $this->assertEquals(2, $groupscount);
+            } else if ($i >= 28 && $i < 30) {
+                $this->assertEquals(3, $groupscount);
+            } else {
+                $this->assertEquals(0, $groupscount);
+            }
+            $i++;
+        }
+
+        $raters = array_values($this->ratingallocate->get_raters_in_course());
+        // Additionally check that the original order of the users has been preserved if group count is equal.
+        // For groupcount 2:
+        $this->assertEquals(array_search($studentonetwogroups, $raters) > array_search($studenttwotwogroups, $raters),
+            array_search($studentonetwogroups->id, $users) > array_search($studenttwotwogroups->id, $users));
+        $this->assertEquals(array_search($studenttwotwogroups, $raters) > array_search($studentthreetwogroups, $raters),
+            array_search($studenttwotwogroups->id, $users) > array_search($studentthreetwogroups->id, $users));
+        // For groupcount 3:
+        $this->assertEquals(array_search($studentonethreegroups, $raters) > array_search($studenttwothreegroups, $raters),
+            array_search($studentonethreegroups->id, $users) > array_search($studenttwothreegroups->id, $users));
+        // For groupcount 1:
+        for ($i =0; $i<25; $i++) {
+            $this->assertEquals(array_values(array_filter($raters,
+                    fn($rater) => count($this->ratingallocate->get_user_groupids($rater->id)) == 1))[$i]->id, $users[$i]);
+        }
+        // For groupcount 0:
+        for ($i = 0; $i<10; $i++) {
+            $this->assertEquals(array_values(array_filter($raters,
+                fn($rater) => count($this->ratingallocate->get_user_groupids($rater->id)) == 0))[$i]->id, $users[$i + 30]);
+        }
+    }
+
+    private function get_choice_id_by_title(string $title): int {
+        return $this->get_choice_by_title($title)->id;
+    }
+
+    private function get_choice_by_title(string $title): stdClass {
+        return array_values(array_filter($this->ratingallocate->get_rateable_choices(),
+            fn($choice) => $choice->title === $title))[0];
+    }
+
+    private function get_allocation_count_for_choice(string $title): int {
+        $choiceswithallocationcount = $this->ratingallocate->get_choices_with_allocationcount();
+        $choiceswithallocationcount = array_filter($choiceswithallocationcount, fn($choice) => $choice->title === $title);
+        return (int) array_values($choiceswithallocationcount)[0]->usercount;
+    }
+
+    private function get_allocations_for_choice(string $title): array {
+        $allocationsofchoice = array_filter($this->ratingallocate->get_allocations(), fn($allocation) => $allocation->choiceid == $this->get_choice_id_by_title($title));
+        return array_map(fn($allocation) => $allocation->userid, $allocationsofchoice);
+    }
+
+    private function allocate_random_users(): void {
+        $this->ratingallocate->add_allocation($this->get_choice_id_by_title('B'), $this->studentsgreen[3]->id);
+        $this->ratingallocate->add_allocation($this->get_choice_id_by_title('B'), $this->studentsred[7]->id);
+        $this->ratingallocate->add_allocation($this->get_choice_id_by_title('C'), $this->studentsblue[9]->id);
+        $this->ratingallocate->add_allocation($this->get_choice_id_by_title('D'), $this->studentsnogroup[2]->id);
+    }
+
+    private function assert_allocation_of_random_users(): void {
+        $this->assertEquals($this->get_choice_id_by_title('B'),
+            array_values($this->ratingallocate->get_allocations_for_user($this->studentsgreen[3]->id))[0]->choiceid);
+        $this->assertEquals($this->get_choice_id_by_title('B'),
+            array_values($this->ratingallocate->get_allocations_for_user($this->studentsred[7]->id))[0]->choiceid);
+        $this->assertEquals($this->get_choice_id_by_title('C'),
+            array_values($this->ratingallocate->get_allocations_for_user($this->studentsblue[9]->id))[0]->choiceid);
+        $this->assertEquals($this->get_choice_id_by_title('D'),
+            array_values($this->ratingallocate->get_allocations_for_user($this->studentsnogroup[2]->id))[0]->choiceid);
+    }
+
+    /**
+     * Test distribution without groups.
+     *
+     * @return void
+     * @throws coding_exception
+     */
+    public function test_distribution_without_groups(): void {
+        $choices = [];
+
+        $letters = range('A', 'E');
+        foreach ($letters as $letter) {
+            $choice = [
+                'title' => "$letter",
+                'explanation' => "Explain Choice $letter",
+                'maxsize' => 8,
+                'active' => true,
+                'usegroups' => false
+            ];
+            $choices[] = $choice;
+        }
+        $mod = mod_ratingallocate_generator::create_instance_with_choices($this,
+            ['course' => $this->course,
+                'strategyopt' => ['countoptions' => 3],
+                'strategy' => 'strategy_order'],
+            $choices);
+        $this->ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $this->teacher);
+
+        // Tests
+        $this->ratingallocate->add_allocation($this->get_choice_id_by_title('A'), $this->studentsnogroup[0]->id);
+        $this->ratingallocate->add_allocation($this->get_choice_id_by_title('A'), $this->studentsnogroup[1]->id);
+        $this->assertEquals(2, $this->get_allocation_count_for_choice('A'));
+        $this->ratingallocate->distribute_users_without_choice(ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY);
+        foreach (range('A', 'E') as $groupname) {
+            $this->assertEquals(8, $this->get_allocation_count_for_choice($groupname));
+        }
+
+        // Reset allocations.
+        $this->ratingallocate->clear_all_allocations();
+
+        // We now test what happens with more users than places in the choices.
+        for ($i = 0; $i < 10; $i++) {
+            mod_ratingallocate_generator::create_user_and_enrol($this, $this->course);
+        }
+        $this->assertEquals(51, count(enrol_get_course_users($this->course->id)));
+        $this->ratingallocate->distribute_users_without_choice(ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY);
+        foreach (range('A', 'E') as $choicetitle) {
+            // We still should have the maximum amount of students assigned to the choices.
+            $this->assertEquals(8, $this->get_allocation_count_for_choice($choicetitle));
+        }
+    }
+
+    /**
+     * Test the distribution of users to choices with group restrictions, using both algorithms.
+     *
+     * @return void
+     */
+    public function test_allocation_with_groups_common_features(): void {
+        $this->test_allocation_with_groups_with_algorithm(ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY);
+        $this->test_allocation_with_groups_with_algorithm(ACTION_DISTRIBUTE_UNALLOCATED_FILL);
+    }
+
+    /**
+     * This is a proper test function. It's private, because it's called with both types of algorithms by
+     *  test_allocation_with_groups function.
+     *
+     * @param string $algorithm the algorithm to use for running this test function
+     * @return void
+     */
+    private function test_allocation_with_groups_with_algorithm(string $algorithm): void {
+        $choices = [];
+
+        $letters = range('A', 'E');
+        foreach ($letters as $letter) {
+            $choice = [
+                'title' => "$letter",
+                'explanation' => "Explain Choice $letter",
+                'maxsize' => 8,
+                'active' => true,
+            ];
+
+            if ($letter === 'D' || $letter === 'E') {
+                $choice['usegroups'] = true;
+            } else {
+                $choice['usegroups'] = false;
+            }
+            $choices[] = $choice;
+        }
+
+        $mod = mod_ratingallocate_generator::create_instance_with_choices($this,
+            ['course' => $this->course,
+                'strategyopt' => ['countoptions' => 3],
+                'strategy' => 'strategy_order'],
+            $choices);
+        $this->ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $this->teacher);
+        // Assign blue and green group to choice D. So D is only available to green and blue students.
+        $this->ratingallocate->update_choice_groups($this->get_choice_id_by_title('D'), [$this->blue->id, $this->green->id]);
+        $this->ratingallocate->distribute_users_without_choice($algorithm);
+        // We could not distribute all users, but choices 'A' to 'D' should be properly filled.
+        foreach (range('A', 'D') as $choicetitle) {
+            $this->assertEquals(8, $this->get_allocation_count_for_choice($choicetitle));
+        }
+        /*print_r(array_map(fn($student) => $student->id, $this->studentsblue));
+        print_r(array_map(fn($student) => $student->id, $this->studentsgreen));
+        print_r($this->get_allocations_for_choice('B'));*/
+        //die();
+
+        // We don't assign a group to E, so E should not be available to any student.
+        $this->assertEquals(0, $this->get_allocation_count_for_choice('E'));
+        // Verify, that choice 'D' only has users from groups blue or green.
+        $this->test_group_memberships();
+
+        // We now assign a group to E, so all users should be distributed, because we got 40 places in total for 40 students.
+        $this->ratingallocate->clear_all_allocations();
+        $this->ratingallocate->update_choice_groups($this->get_choice_id_by_title('E'), [$this->red->id]);
+        $this->ratingallocate->distribute_users_without_choice($algorithm);
+        foreach (range('A', 'E') as $groupname) {
+            $this->assertEquals(8, $this->get_allocation_count_for_choice($groupname));
+        }
+        $this->test_group_memberships();
+    }
+
+    /**
+     * Test the distribution of users to choices with group restrictions, using both algorithms.
+     *
+     * @return void
+     */
+    public function test_allocation_without_groups_common_features(): void {
+        $this->test_allocation_without_groups_with_algorithm(ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY);
+        $this->test_allocation_without_groups_with_algorithm(ACTION_DISTRIBUTE_UNALLOCATED_FILL);
+    }
+
+    private function test_allocation_without_groups_with_algorithm(string $algorithm): void {
+        $choices = [];
+
+        $letters = range('A', 'E');
+        foreach ($letters as $letter) {
+            $choice = [
+                'title' => "$letter",
+                'explanation' => "Explain Choice $letter",
+                'maxsize' => 8,
+                'active' => true,
+            ];
+            $choices[] = $choice;
+        }
+
+        $mod = mod_ratingallocate_generator::create_instance_with_choices($this,
+            ['course' => $this->course,
+                'strategyopt' => ['countoptions' => 3],
+                'strategy' => 'strategy_order'],
+            $choices);
+        $this->ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $this->teacher);
+
+        // We now test what happens with more users than places in the choices.
+        $newusers = [];
+        for ($i = 0; $i < 10; $i++) {
+            $newusers[] = mod_ratingallocate_generator::create_user_and_enrol($this, $this->course);
+        }
+        $this->assertEquals(51, count(enrol_get_course_users($this->course->id)));
+        $this->ratingallocate->distribute_users_without_choice($algorithm);
+        foreach (range('A', 'E') as $choicetitle) {
+            // We still should have the maximum amount of students assigned to the choices.
+            $this->assertEquals(8, $this->get_allocation_count_for_choice($choicetitle));
+        }
+        $this->ratingallocate->clear_all_allocations();
+        foreach ($newusers as $user) {
+            delete_user($user);
+        }
+    }
+
+    /**
+     * Test the EQUALLY algorithm without groups. The algorithm tries to distribute the users so that each choice has equal places
+     * left or at most there is a difference of one user for the left places per choice.
+     *
+     * @return void
+     */
+    public function test_distribute_equally_without_groups(): void {
+        $choices = [];
+
+        $letters = range('A', 'E');
+        $i = 14;
+        foreach ($letters as $letter) {
+            $choice = [
+                'title' => "$letter",
+                'explanation' => "Explain Choice $letter",
+                'active' => true,
+                'usegroups' => false,
+                // We choose 14, 12, 10, 8 and 6 maxsize values for the groups A, B, C, D, E.
+                // This means 50 places for 40 users in the course.
+                'maxsize' => $i
+            ];
+
+            $choices[] = $choice;
+            $i -= 2;
+        }
+        $mod = mod_ratingallocate_generator::create_instance_with_choices($this,
+            ['course' => $this->course,
+                'strategyopt' => ['countoptions' => 3],
+                'strategy' => 'strategy_order'],
+            $choices);
+        $this->ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $this->teacher);
+
+        // Randomly manually allocate some students to some choices to see if the algorithm can deal with that.
+        $this->allocate_random_users();
+
+        $this->ratingallocate->distribute_users_without_choice(ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY);
+        $i = 14;
+        foreach ($letters as $groupname) {
+            // All choices should be equally filled up. We have 50 places and 40 users, so every choice should have 2 places left
+            // after distribution.
+            $this->assertEquals($i - 2, $this->get_allocation_count_for_choice($groupname));
+            $i -= 2;
+        }
+
+        // Assert the allocations already existing before have not changed.
+        $this->assert_allocation_of_random_users();
+    }
+
+    /**
+     * Test the FILL algorithm without groups. This algorithm just fills up every choice. Choices with least places left are
+     * being filled up first.
+     *
+     * @return void
+     */
+    public function test_distribute_fill_without_groups(): void {
+        $choices = [];
+
+        $letters = range('A', 'E');
+        $i = 14;
+        foreach ($letters as $letter) {
+            $choice = [
+                'title' => "$letter",
+                'explanation' => "Explain Choice $letter",
+                'active' => true,
+                'usegroups' => false,
+                // We choose 14, 12, 10, 8 and 6 maxsize values for the groups A, B, C, D, E.
+                // This means 50 places for 40 users in the course.
+                'maxsize' => $i
+            ];
+
+            $choices[] = $choice;
+            $i -= 2;
+        }
+        $mod = mod_ratingallocate_generator::create_instance_with_choices($this,
+            ['course' => $this->course,
+                'strategyopt' => ['countoptions' => 3],
+                'strategy' => 'strategy_order'],
+            $choices);
+        $this->ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $this->teacher);
+
+        // Randomly manually allocate some students to some choices to see if the algorithm can deal with that.
+        $this->allocate_random_users();
+
+        $this->ratingallocate->distribute_users_without_choice(ACTION_DISTRIBUTE_UNALLOCATED_FILL);
+
+        $i = 14;
+        foreach ($letters as $groupname) {
+            // A choice should be filled up completely before going for the next one by this algorithm. Choices with least places
+            // left should be first filled up. This would mean we fill 'E', then 'D', then 'C', then 'B' and 4 users should be left
+            // for 'A'.
+            if ($groupname == 'A') {
+                $this->assertEquals(4, $this->get_allocation_count_for_choice($groupname));
+            } else {
+                $this->assertEquals($i, $this->get_allocation_count_for_choice($groupname));
+            }
+            $i -= 2;
+        }
+
+        // Assert the allocations already existing before have not changed.
+        $this->assert_allocation_of_random_users();
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022120100;        // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2022120101;        // The current module version (Date: YYYYMMDDXX)
 $plugin->requires = 2020061500;         // Requires Moodle 3.9+.
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 'v4.0-r1';


### PR DESCRIPTION
As followup for the group restriction PR I developed a feature targeting #232 and #124.

As stated in #232 by @danmarsden there is another solution for this which however seems to go for a different approach.

@danmarsden, @Laur0r Let me know how to deal with that. I can offer to integrate all 3 ways (the 2 ways in this PR and https://github.com/danmarsden/moodle-mod_ratingallocate/commit/e9c71d7612f6cfa021caf413e46273bb7f66ec3d) of distributing unallocated users? However, it looks to me as the feature of @danmarsden depends on some other features? So maybe this should be handled differently.