### PR TITLE
Show groups in allocation table, improve allocation table view

### DIFF
--- a/classes/ratings_and_allocations_table.php
+++ b/classes/ratings_and_allocations_table.php
@@ -164,6 +164,12 @@ class ratings_and_allocations_table extends \table_sql {
 
         foreach ($this->choicenames as $choiceid => $choicetitle) {
             $columns[] = self::CHOICE_COL . $choiceid;
+            $choice = $this->ratingallocate->get_choices()[$choiceid];
+            $choicegroups = array_map(fn($group) => groups_get_group_name($group->id), $this->ratingallocate->get_choice_groups($choiceid));
+            if (!empty($choice->usegroups) && !empty($choicegroups)) {
+                $choicetitle .= ' <br/>' . \html_writer::span('(' . implode(';', $choicegroups) . ')',
+                        'groupsinchoiceheadings');
+            }
             $headers[] = $choicetitle;
             if ($this->is_downloading()) {
                 $columns[] = self::CHOICE_COL . $choiceid . self::EXPORT_CHOICE_TEXT_SUFFIX;

--- a/classes/ratings_and_allocations_table.php
+++ b/classes/ratings_and_allocations_table.php
@@ -184,9 +184,10 @@ class ratings_and_allocations_table extends \table_sql {
 
         // Set additional table settings.
         $this->sortable(true, 'lastname');
-        $tableclasses ='ratingallocate_ratings_table';
+        $tableclasses = 'ratingallocate_ratings_table';
         if ($this->showgroups) {
             $tableclasses .= ' includegroups';
+            $this->no_sorting('groups');
         }
         $this->set_attribute('class', $tableclasses);
 

--- a/classes/ratings_and_allocations_table.php
+++ b/classes/ratings_and_allocations_table.php
@@ -178,7 +178,11 @@ class ratings_and_allocations_table extends \table_sql {
 
         // Set additional table settings.
         $this->sortable(true, 'lastname');
-        $this->set_attribute('class', 'ratingallocate_ratings_table');
+        $tableclasses ='ratingallocate_ratings_table';
+        if ($this->showgroups) {
+            $tableclasses .= ' includegroups';
+        }
+        $this->set_attribute('class', $tableclasses);
 
         $this->initialbars(true);
 

--- a/form_manual_allocation.php
+++ b/form_manual_allocation.php
@@ -134,7 +134,7 @@ class manual_alloc_form extends moodleform {
         $table->build_table_by_sql($ratingdata, $this->ratingallocate->get_allocations(), true);
         $tableoutput = ob_get_contents();
         ob_end_clean();
-        $mform->addElement('html', $tableoutput);
+        $mform->addElement('html', html_writer::div($tableoutput, 'ratingallocate_ratings_table_container'));
 
         $mform->setDefault('page', $table->get_page_start() / $table->get_page_size());
 

--- a/locallib.php
+++ b/locallib.php
@@ -908,6 +908,8 @@ class ratingallocate {
                     $this->get_ratings_for_rateable_choices(), $this->get_raters_in_course(),
                     $this->get_allocations(), $this);
 
+            $output = html_writer::div($output, 'ratingallocate_ratings_table_container');
+
             $output .= html_writer::empty_tag('br', array());
             $output .= $OUTPUT->single_button(new moodle_url('/mod/ratingallocate/view.php', array(
                     'id' => $this->coursemodule->id)), get_string('back'), 'get');

--- a/styles.css
+++ b/styles.css
@@ -90,6 +90,10 @@
     z-index: 3;
 }
 
+.ratingallocate_ratings_table .groupsinchoiceheadings {
+    font-size: xx-small;
+}
+
 .ratingallocate_ratings_table tr.ratingallocate_summary td {
     position: sticky;
     bottom: -2px;

--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,11 @@
     white-space: normal;
 }
 
+.ratingallocate_ratings_table {
+    overflow-x: auto;
+    overflow-y: auto;
+}
+
 .ratingallocate_ratings_table tr.ratingallocate_summary,
 .ratingallocate_ratings_table span.ratingallocate_member {
     font-weight: bold;
@@ -65,4 +70,33 @@
 
 .ratingallocate_distribute_unallocated {
     margin: 1em 1em 0 0;
+}
+
+.ratingallocate_ratings_table tbody td:first-child {
+    position: sticky;
+    left: -2px;
+    background-color: #FFFFFF;
+}
+
+.ratingallocate_ratings_table tr.ratingallocate_summary td {
+    position: sticky;
+    bottom: -2px;
+    background-color: #FFFFFF;
+}
+
+.ratingallocate_ratings_table thead th {
+    background-color: #FFFFFF;
+    position: sticky;
+    top: -2px;
+    z-index: 1;
+}
+
+.ratingallocate_ratings_table thead th:first-child,
+.ratingallocate_ratings_table tr.ratingallocate_summary td:first-child {
+    left: -2px;
+    z-index: 2;
+}
+
+.ratingallocate_ratings_table_container .no-overflow {
+    max-height: 80vh;
 }

--- a/styles.css
+++ b/styles.css
@@ -72,6 +72,22 @@
     left: -2px;
     background-color: #fff;
     z-index: 1;
+    min-width: 10rem;
+    max-width: 10rem;
+}
+
+.ratingallocate_ratings_table.includegroups tbody td:nth-child(2) {
+    position: sticky;
+    left: 9.9rem;
+    background-color: #fff;
+    z-index: 2;
+}
+
+.ratingallocate_ratings_table.includegroups thead th:nth-child(2) {
+    position: sticky;
+    left: 9.9rem;
+    background-color: #fff;
+    z-index: 3;
 }
 
 .ratingallocate_ratings_table tr.ratingallocate_summary td {
@@ -90,7 +106,7 @@
 .ratingallocate_ratings_table thead th:first-child,
 .ratingallocate_ratings_table tr.ratingallocate_summary td:first-child {
     left: -2px;
-    z-index: 2;
+    z-index: 3;
 }
 
 .ratingallocate_ratings_table_container .no-overflow {

--- a/styles.css
+++ b/styles.css
@@ -8,11 +8,6 @@
     white-space: normal;
 }
 
-.ratingallocate_ratings_table {
-    overflow-x: auto;
-    overflow-y: auto;
-}
-
 .ratingallocate_ratings_table tr.ratingallocate_summary,
 .ratingallocate_ratings_table span.ratingallocate_member {
     font-weight: bold;
@@ -75,17 +70,18 @@
 .ratingallocate_ratings_table tbody td:first-child {
     position: sticky;
     left: -2px;
-    background-color: #FFFFFF;
+    background-color: #fff;
+    z-index: 1;
 }
 
 .ratingallocate_ratings_table tr.ratingallocate_summary td {
     position: sticky;
     bottom: -2px;
-    background-color: #FFFFFF;
+    background-color: #fff;
 }
 
 .ratingallocate_ratings_table thead th {
-    background-color: #FFFFFF;
+    background-color: #fff;
     position: sticky;
     top: -2px;
     z-index: 1;
@@ -98,5 +94,5 @@
 }
 
 .ratingallocate_ratings_table_container .no-overflow {
-    max-height: 80vh;
+    overflow: unset;
 }

--- a/styles.css
+++ b/styles.css
@@ -67,26 +67,33 @@
     margin: 1em 1em 0 0;
 }
 
+.ratingallocate_ratings_table {
+    border-collapse: separate;
+    border-spacing: 0;
+}
+
+.ratingallocate_ratings_table thead th:first-child,
 .ratingallocate_ratings_table tbody td:first-child {
     position: sticky;
-    left: -2px;
-    background-color: #fff;
-    z-index: 1;
+    left: 0;
     min-width: 10rem;
     max-width: 10rem;
 }
 
-.ratingallocate_ratings_table.includegroups tbody td:nth-child(2) {
-    position: sticky;
-    left: 9.9rem;
-    background-color: #fff;
-    z-index: 2;
-}
-
+.ratingallocate_ratings_table.includegroups tbody td:nth-child(2),
 .ratingallocate_ratings_table.includegroups thead th:nth-child(2) {
     position: sticky;
-    left: 9.9rem;
-    background-color: #fff;
+    left: 10rem;
+    border-right: 2px solid #dee2e6;
+}
+
+.ratingallocate_ratings_table:not(.includegroups) tbody td:first-child,
+.ratingallocate_ratings_table:not(.includegroups) thead th:first-child {
+    border-right: 2px solid #dee2e6;
+}
+
+.ratingallocate_ratings_table thead th:first-child,
+.ratingallocate_ratings_table.includegroups thead th:nth-child(2) {
     z-index: 3;
 }
 
@@ -96,21 +103,22 @@
 
 .ratingallocate_ratings_table tr.ratingallocate_summary td {
     position: sticky;
-    bottom: -2px;
+    bottom: 0;
     background-color: #fff;
 }
 
 .ratingallocate_ratings_table thead th {
     background-color: #fff;
     position: sticky;
-    top: -2px;
-    z-index: 1;
+    top: 0;
+    z-index: 2;
 }
 
-.ratingallocate_ratings_table thead th:first-child,
-.ratingallocate_ratings_table tr.ratingallocate_summary td:first-child {
-    left: -2px;
-    z-index: 3;
+.ratingallocate_ratings_table tbody td:first-child,
+.ratingallocate_ratings_table.includegroups tbody td:nth-child(2) {
+    background-color: #fff;
+    z-index: 1;
+    font-weight: bold;
 }
 
 .ratingallocate_ratings_table_container .no-overflow {


### PR DESCRIPTION
Closes #253
Closes #254

Additional info: The table will now keep a fixed percentage of the viewport height. This allows the trainer to zoom out in the browser to increase the count of users he is seeing at the same time. This means: The bigger your screen the easier it is for you to edit the allocations manually while it is still ok for users with smaller screens.