### PR TITLE
Fix/get raters with access

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -178,8 +178,7 @@ class ratingallocate {
      * Returns all users enrolled in the course the ratingallocate is in
      * @throws moodle_exception
      */
-    public function get_raters_in_course(): array
-    {
+    public function get_raters_in_course(): array {
 
         $modinfo = get_fast_modinfo($this->course);
         $cm = $modinfo->get_cm($this->coursemodule->id);

--- a/locallib.php
+++ b/locallib.php
@@ -27,6 +27,7 @@
  */
 defined('MOODLE_INTERNAL') || die();
 
+use core_availability\info_module;
 use ratingallocate\db as this_db;
 
 global $CFG;
@@ -175,10 +176,21 @@ class ratingallocate {
 
     /**
      * Returns all users enrolled in the course the ratingallocate is in
+     * @throws moodle_exception
      */
-    public function get_raters_in_course() {
+    public function get_raters_in_course(): array
+    {
+
+        $modinfo = get_fast_modinfo($this->course);
+        $cm = $modinfo->get_cm($this->coursemodule->id);
+
         $raters = get_enrolled_users($this->context, 'mod/ratingallocate:give_rating');
-        return $raters;
+        $info = new info_module($cm);
+        // Only show raters who had the ability to access this activity. This funktion ignores the visibility setting,
+        // so the ratings and allocations are still shown, even when the activity is hidden
+        $filteredraters = $info->filter_user_list($raters);
+
+        return $filteredraters;
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023051200;        // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2023050900;        // The current module version (Date: YYYYMMDDXX)
 $plugin->requires = 2020061500;         // Requires Moodle 3.9+.
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 'v4.0-r1';

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022120100;        // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2023051200;        // The current module version (Date: YYYYMMDDXX)
 $plugin->requires = 2020061500;         // Requires Moodle 3.9+.
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 'v4.0-r1';


### PR DESCRIPTION
Filters the raters by accessibility of the activity, so that only users who were able to rate are shown in the ratings and allocations table.