### PR TITLE
Fix deprecation warnings, adapt unit test timeout

### DIFF
--- a/solver/edmonds-karp.php
+++ b/solver/edmonds-karp.php
@@ -114,7 +114,7 @@ class solver_edmonds_karp extends distributor {
                 foreach ($edges as $key2 => $edge) {
 
                     if ($dists[$edge->to] + $edge->weight < $dists[$edge->to]) { // if weight[u] + w < weight[v]:
-                        print_error('negative_cycle', 'ratingallocate');
+                        throw new \moodle_exception('negative_cycle', 'ratingallocate');
                     }
                 }
             }

--- a/solver/ford-fulkerson-koegel.php
+++ b/solver/ford-fulkerson-koegel.php
@@ -131,7 +131,7 @@ class solver_ford_fulkerson extends distributor {
 
         // A valid groupdistribution graph can't contain a negative edge
         if ($counter == $limit) {
-            print_error('negative_cycle', 'ratingallocate');
+            throw new \moodle_exception('negative_cycle', 'ratingallocate');
         }
 
         // If there is no path to $to, return null

--- a/solver/solver-template.php
+++ b/solver/solver-template.php
@@ -227,7 +227,7 @@ class distributor {
      */
     protected function augment_flow($path) {
         if (is_null($path) or count($path) < 2) {
-            print_error('invalid_path', 'ratingallocate');
+            throw new \moodle_exception('invalid_path', 'ratingallocate');
         }
 
         // Walk along the path, from s to t

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -353,7 +353,7 @@ class mod_ratingallocate_generated_module {
                 $this->moddb, $this->teacher);
         $timeneeded = $ratingallocate->distrubute_choices();
         $tc->assertGreaterThan(0, $timeneeded);
-        $tc->assertLessThan(1.0, $timeneeded, 'Allocation is very slow');
+        $tc->assertLessThan(2.0, $timeneeded, 'Allocation is very slow');
         $this->allocations = $ratingallocate->get_allocations();
     }
 }

--- a/view.php
+++ b/view.php
@@ -44,7 +44,7 @@ if ($id) {
     $course = get_course($ratingallocate->course);
     $cm = get_coursemodule_from_instance('ratingallocate', $ratingallocate->id, $course->id, false, MUST_EXIST);
 } else {
-    print_error('no_id_or_m_error', RATINGALLOCATE_MOD_NAME);
+    throw new \moodle_exception('no_id_or_m_error', RATINGALLOCATE_MOD_NAME);
 }
 
 require_login($course, true, $cm);


### PR DESCRIPTION
Some small fixes.

In https://tracker.moodle.org/browse/MDL-69936 it has been decided to deprecate `print_error` in favor of `moodle_exception`. The first commit replaces all occurrences.

Also, I discovered that unit tests are sometimes failing for me, because the algorithm now is a bit slower with the group restriction feature. So I raised the assertion time limit.

