### PR TITLE
Feature/groupfilter for manual allocation

### DIFF
--- a/classes/ratings_and_allocations_table.php
+++ b/classes/ratings_and_allocations_table.php
@@ -588,7 +588,7 @@ class ratings_and_allocations_table extends \table_sql {
         if ($this->showallocnecessary) {
             $sql .= "LEFT JOIN ({ratingallocate_allocations} a " .
                 "JOIN {ratingallocate_choices} c2 ON c2.id = a.choiceid AND c2.active=1 " .
-                "AND a.ratingallocateid = :ratingallocateid )" .
+                "AND a.ratingallocateid = :ratingallocateid2 )" .
                 "ON u.id=a.userid " .
                 "WHERE a.id is null AND u.id in (" . implode(",", $userids) . ") ";
         } else {
@@ -614,6 +614,7 @@ class ratings_and_allocations_table extends \table_sql {
                 $DB->get_records_sql($sql,
                         array(
                                 'ratingallocateid' => $this->ratingallocate->ratingallocate->id,
+                                'ratingallocateid2' => $this->ratingallocate->ratingallocate->id,
                                 'groupselect' => $this->groupselect
                         )
                 )

--- a/classes/ratings_and_allocations_table.php
+++ b/classes/ratings_and_allocations_table.php
@@ -595,15 +595,16 @@ class ratings_and_allocations_table extends \table_sql {
             $sql .= "WHERE u.id in (" . implode(",", $userids) . ") ";
         }
         if ($this->groupselect == -1) {
-            $sql .= "AND u.id not in ( SELECT gm.userid FROM {groups_members} gm WHERE gm.groupid in (" .
-                implode(",",
-                    array_map(
-                        function($o) {
-                            return $o->id;
-                        },
-                        $this->groupsofallchoices)) .
-                ") ) ";
-        } else {
+            $sql .= "AND u.id not in ( SELECT distinct gm.userid FROM {groups_members} gm WHERE gm.groupid in (null";
+            if (!empty($gmgroupid = implode(",",
+                array_map(
+                    function($o) {
+                        return $o->id;
+                    },
+                    $this->groupsofallchoices)))) {
+                $sql .= "," . $gmgroupid . ") ) ";
+            }
+        } else if ($this->groupselect != 0) {
             $sql .= "AND u.id in ( SELECT gm.userid FROM {groups_members} gm WHERE gm.groupid= :groupselect ) ";
         }
         return array_map(

--- a/classes/ratings_and_allocations_table.php
+++ b/classes/ratings_and_allocations_table.php
@@ -376,7 +376,7 @@ class ratings_and_allocations_table extends \table_sql {
         }
 
         foreach ($this->choicesum as $choiceid => $sum) {
-            if (array_key_exists($choiceid, $this->filter_choiceids(array_keys($this->choicenames)))) {
+            if (in_array($choiceid, $this->filter_choiceids(array_keys($this->choicenames)))) {
                 $row[] = get_string(
                     'ratings_table_sum_allocations_value',
                     RATINGALLOCATE_MOD_NAME,
@@ -588,7 +588,7 @@ class ratings_and_allocations_table extends \table_sql {
         if ($this->showallocnecessary) {
             $sql .= "LEFT JOIN ({ratingallocate_allocations} a " .
                 "JOIN {ratingallocate_choices} c2 ON c2.id = a.choiceid AND c2.active=1 " .
-                "AND a.ratingallocateid = :ratingallocateid2 )" .
+                "AND a.ratingallocateid = :ratingallocateid )" .
                 "ON u.id=a.userid " .
                 "WHERE a.id is null AND u.id in (" . implode(",", $userids) . ") ";
         } else {
@@ -614,7 +614,6 @@ class ratings_and_allocations_table extends \table_sql {
                 $DB->get_records_sql($sql,
                         array(
                                 'ratingallocateid' => $this->ratingallocate->ratingallocate->id,
-                                'ratingallocateid2' => $this->ratingallocate->ratingallocate->id,
                                 'groupselect' => $this->groupselect
                         )
                 )

--- a/classes/ratings_and_allocations_table.php
+++ b/classes/ratings_and_allocations_table.php
@@ -184,7 +184,7 @@ class ratings_and_allocations_table extends \table_sql {
         }
 
         // Setup filter.
-        $this->setup_filter($hidenorating, $showallocnecessary,$groupselect);
+        $this->setup_filter($hidenorating, $showallocnecessary, $groupselect);
 
         $filteredchoices = $this->filter_choiceids(array_keys($this->choicenames));
         foreach ($filteredchoices as $choiceid) {
@@ -282,7 +282,12 @@ class ratings_and_allocations_table extends \table_sql {
      */
     private function add_group_row(): void {
         if ($this->is_downloading()) {
-            $choiceids = array_map(function ($c) {return $c->id;}, $this->ratingallocate->get_choices());
+            $choiceids = array_map(
+                function ($c) {
+                    return $c->id;
+                },
+                $this->ratingallocate->get_choices()
+            );
             $choices = $this->ratingallocate->get_choices_by_id($this->filter_choiceids($choiceids));
             $row = [];
             foreach ($choices as $choice) {
@@ -564,8 +569,7 @@ class ratings_and_allocations_table extends \table_sql {
      * @param $userids array ids, which should be filtered.
      * @return array of filtered user ids.
      */
-    private function filter_userids($userids)
-    {
+    private function filter_userids($userids) {
         global $DB;
         if (!$userids) {
             return $userids;
@@ -592,7 +596,13 @@ class ratings_and_allocations_table extends \table_sql {
         }
         if ($this->groupselect == -1) {
             $sql .= "AND u.id not in ( SELECT gm.userid FROM {groups_members} gm WHERE gm.groupid in (" .
-                implode(",", array_map(function($o) { return $o->id;}, $this->groupsofallchoices)) . ") ) ";
+                implode(",",
+                    array_map(
+                        function($o) {
+                            return $o->id;
+                        },
+                        $this->groupsofallchoices)) .
+                ") ) ";
         } else {
             $sql .= "AND u.id in ( SELECT gm.userid FROM {groups_members} gm WHERE gm.groupid= :groupselect ) ";
         }
@@ -610,14 +620,13 @@ class ratings_and_allocations_table extends \table_sql {
         );
     }
 
-    private function filter_choiceids($choiceids)
-    {
+    private function filter_choiceids($choiceids) {
         global $DB;
         if (!$choiceids) {
             return $choiceids;
         }
 
-        if ($this->groupselect == 0){
+        if ($this->groupselect == 0) {
             return $choiceids;
         }
 

--- a/form_manual_allocation.php
+++ b/form_manual_allocation.php
@@ -94,7 +94,7 @@ class manual_alloc_form extends moodleform {
         }
         $groupsmenu[0] = get_string('allparticipants');
         $groupsmenu[-1] = get_string('nogroup', 'enrol');
-        foreach($allgroups as $gid => $unused) {
+        foreach ($allgroups as $gid => $unused) {
             $groupsmenu[$gid] = $allgroups[$gid]->name;
         }
         if (count($groupsmenu) > 1) {
@@ -145,7 +145,6 @@ class manual_alloc_form extends moodleform {
         $mform->getElement('show_alloc_necessary')->setChecked($filter['showallocnecessary']);
         $mform->setDefault('filtergroup', $filter['groupselect']);
         $mform->getElement('filtergroup')->setSelected($filter['groupselect']);
-
 
         $PAGE->requires->js_call_amd('mod_ratingallocate/radiobuttondeselect', 'init');
 

--- a/form_manual_allocation.php
+++ b/form_manual_allocation.php
@@ -99,6 +99,7 @@ class manual_alloc_form extends moodleform {
         }
         if (count($groupsmenu) > 1) {
             $mform->addElement('select', 'filtergroup', get_string('group'), $groupsmenu);
+            $mform->addHelpButton('filtergroup', 'filtergroup', RATINGALLOCATE_MOD_NAME);
         }
 
         $mform->addElement('submit', 'update_filter',

--- a/form_manual_allocation.php
+++ b/form_manual_allocation.php
@@ -123,6 +123,7 @@ class manual_alloc_form extends moodleform {
 
         $hidenorating = null;
         $showallocnecessary = null;
+        $groupselect = null;
         // Get filter settings.
         if ($this->is_submitted()) {
             $hidenorating = $mform->getSubmitValue('hide_users_without_rating');

--- a/form_manual_allocation.php
+++ b/form_manual_allocation.php
@@ -73,6 +73,7 @@ class manual_alloc_form extends moodleform {
     }
 
     protected function render_filter() {
+        global $COURSE;
         $mform = &$this->_form;
 
         $mform->addElement('advcheckbox', 'hide_users_without_rating',
@@ -84,6 +85,21 @@ class manual_alloc_form extends moodleform {
                 get_string('filter_show_alloc_necessary', RATINGALLOCATE_MOD_NAME),
                 null, array(0, 1));
         $mform->setType('show_alloc_necessary', PARAM_BOOL);
+
+        // Filter by group.
+        $choicegroups = $this->ratingallocate->get_all_groups_of_choices();
+        $allgroups = array();
+        foreach ($choicegroups as $choicegroup) {
+            $allgroups[$choicegroup] = groups_get_group($choicegroup);
+        }
+        $groupsmenu[0] = get_string('allparticipants');
+        $groupsmenu[-1] = get_string('nogroup', 'enrol');
+        foreach($allgroups as $gid => $unused) {
+            $groupsmenu[$gid] = $allgroups[$gid]->name;
+        }
+        if (count($groupsmenu) > 1) {
+            $mform->addElement('select', 'filtergroup', get_string('group'), $groupsmenu);
+        }
 
         $mform->addElement('submit', 'update_filter',
                 get_string('update_filter', RATINGALLOCATE_MOD_NAME));
@@ -111,6 +127,7 @@ class manual_alloc_form extends moodleform {
         if ($this->is_submitted()) {
             $hidenorating = $mform->getSubmitValue('hide_users_without_rating');
             $showallocnecessary = $mform->getSubmitValue('show_alloc_necessary');
+            $groupselect = $mform->getSubmitValue('filtergroup');
         }
 
         // Create and set up the flextable for ratings and allocations.
@@ -118,7 +135,7 @@ class manual_alloc_form extends moodleform {
                 $this->ratingallocate->get_options_titles($differentratings), $this->ratingallocate,
                 'manual_allocation', 'mod_ratingallocate_manual_allocation', false);
         $table->setup_table($this->ratingallocate->get_rateable_choices(),
-                $hidenorating, $showallocnecessary);
+                $hidenorating, $showallocnecessary, $groupselect);
 
         $filter = $table->get_filter();
 
@@ -126,6 +143,9 @@ class manual_alloc_form extends moodleform {
         $mform->getElement('hide_users_without_rating')->setChecked($filter['hidenorating']);
         $mform->setDefault('show_alloc_necessary', $filter['showallocnecessary']);
         $mform->getElement('show_alloc_necessary')->setChecked($filter['showallocnecessary']);
+        $mform->setDefault('filtergroup', $filter['groupselect']);
+        $mform->getElement('filtergroup')->setSelected($filter['groupselect']);
+
 
         $PAGE->requires->js_call_amd('mod_ratingallocate/radiobuttondeselect', 'init');
 

--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -452,3 +452,8 @@ $string['privacy:metadata:preference:flextable_manual_filter'] =
 
 $string['filtertabledesc'] = 'Describes the filters that are applied to the allocation table.';
 $string['filtermanualtabledesc'] = 'Describes the filters that are applied to the table of the manual allocation form.';
+$string['filtergroup'] = 'Group filter';
+$string['filtergroup_help'] = '* Select a group in order to filter course participants according to the groups they are in,
+and ratable choices by groups that had the ability to access them.
+* Only groups used in the *use groups* option can be selected.
+* If *no group* is selected, users that are in none of the groups used by a choice are shown.';

--- a/locallib.php
+++ b/locallib.php
@@ -179,7 +179,7 @@ class ratingallocate {
     const NOTIFY_MESSAGE = 'notifymessage';
 
     /**
-     * Returns all users enrolled in the course the ratingallocate is in
+     * Returns all users enrolled in the course the ratingallocate is in, who were able to access the activity
      * @throws moodle_exception
      */
     public function get_raters_in_course(): array {

--- a/locallib.php
+++ b/locallib.php
@@ -1812,6 +1812,19 @@ class ratingallocate {
     }
 
     /**
+     * Returns an array of choices with the given ids
+     *
+     * @param $ids array choiceids
+     * @return array choices
+     * @throws dml_exception
+     */
+    public function get_choices_by_id($ids) {
+        global $DB;
+        return $DB->get_records_list(this_db\ratingallocate_choices::TABLE,
+                'id', $ids);
+    }
+
+    /**
      * Returns all memberships of a user for rateable choices in this instance of ratingallocate
      */
     public function get_allocations_for_user($userid) {

--- a/tests/mod_ratingallocate_processor_test.php
+++ b/tests/mod_ratingallocate_processor_test.php
@@ -134,7 +134,7 @@ class mod_ratingallocate_processor_test extends \advanced_testcase {
         $this->resetAfterTest();
 
         $course = $this->getDataGenerator()->create_course();
-        $teacher = mod_ratingallocate_generator::create_user_and_enrol($this, $course, true);
+        $teacher = \mod_ratingallocate_generator::create_user_and_enrol($this, $course, true);
         $this->setUser($teacher);
 
         // Create two groups.
@@ -146,18 +146,18 @@ class mod_ratingallocate_processor_test extends \advanced_testcase {
             'name' => 'group2'));
 
         // Add 1 member to each group, and 1 member to both groups.
-        $student1 = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+        $student1 = \mod_ratingallocate_generator::create_user_and_enrol($this, $course);
         groups_add_member($group1->id, $student1->id);
-        $student2 = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+        $student2 = \mod_ratingallocate_generator::create_user_and_enrol($this, $course);
         groups_add_member($group2->id, $student2->id);
-        $student3 = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+        $student3 = \mod_ratingallocate_generator::create_user_and_enrol($this, $course);
         groups_add_member($group1->id, $student3->id);
         groups_add_member($group2->id, $student3->id);
-        $student4 = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+        $student4 = \mod_ratingallocate_generator::create_user_and_enrol($this, $course);
 
         // Setup ratingallocate instance.
-        $mod = mod_ratingallocate_generator::create_instance_with_choices($this, array('course' => $course), $this->get_choice_data());
-        $ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $teacher);
+        $mod = \mod_ratingallocate_generator::create_instance_with_choices($this, array('course' => $course), $this->get_choice_data());
+        $ratingallocate = \mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $teacher);
 
         // Map choice titles to choice IDs, group names to group IDs.
         $choices = $ratingallocate->get_rateable_choices();

--- a/tests/mod_ratingallocate_processor_test.php
+++ b/tests/mod_ratingallocate_processor_test.php
@@ -138,10 +138,10 @@ class mod_ratingallocate_processor_test extends \advanced_testcase {
 
         // Create two groups.
         $group1 = $this->getDataGenerator()->create_group(array(
-            'courseid' => $course,
+            'courseid' => $course->id,
             'name' => 'group1'));
         $group2 = $this->getDataGenerator()->create_group(array(
-            'courseid' => $course,
+            'courseid' => $course->id,
             'name' => 'group2'));
 
         // Add 1 member to each group, and 1 member to both groups.

--- a/tests/mod_ratingallocate_processor_test.php
+++ b/tests/mod_ratingallocate_processor_test.php
@@ -178,10 +178,10 @@ class mod_ratingallocate_processor_test extends \advanced_testcase {
 
         // Test the group filter only (set hidenorating and showalloccount to false).
 
-        // Count of users in total should be equal to 6.
+        // Count of participants in total should be equal to 4.
         $table = $this->setup_ratings_table_with_filter_options($ratingallocate, false, false, 0);
-        self::assertEquals(6, count($table->rawdata),
-            "Filtering the users to all course participants should return 6 users.");
+        self::assertEquals(4, count($table->rawdata),
+            "Filtering the users to all course participants who could access the activity should return 4 users.");
 
         // Count of users in group1 should be equal to 2.
         $table = $this->setup_ratings_table_with_filter_options($ratingallocate, false, false, $groupidmap['group1']);

--- a/tests/mod_ratingallocate_processor_test.php
+++ b/tests/mod_ratingallocate_processor_test.php
@@ -193,10 +193,10 @@ class mod_ratingallocate_processor_test extends \advanced_testcase {
         self::assertEquals(2, count($table->rawdata),
             "Filtering the users to those in group2 should return 2 users.");
 
-        // Count of users in neither group used in the ratingallocate activity should be equal to 3.
+        // Count of users in neither group used in the ratingallocate activity should be equal to 1.
         $table = $this->setup_ratings_table_with_filter_options($ratingallocate, false, false, -1);
-        self::assertEquals(3, count($table->rawdata),
-            "Filtering the users to those in neither group should return 3 users.");
+        self::assertEquals(1, count($table->rawdata),
+            "Filtering the users to those in neither group should return 1 user.");
     }
 
     /**

--- a/tests/mod_ratingallocate_processor_test.php
+++ b/tests/mod_ratingallocate_processor_test.php
@@ -98,36 +98,108 @@ class mod_ratingallocate_processor_test extends \advanced_testcase {
      * @covers \classes\ratings_and_allocations_table
      */
     public function test_ratings_table_filter() {
-        // Setup the ratingallocate instanz with 4 Students.
+        $this->resetAfterTest();
+
+        // Setup the ratingallocate instance with 4 Students.
         $ratingallocate = \mod_ratingallocate_generator::get_small_ratingallocate_for_filter_tests($this);
 
         $this->alter_user_base_for_filter_test($ratingallocate);
 
         // Count of users with ratings should equal to 4.
-        $table = $this->setup_ratings_table_with_filter_options($ratingallocate, true, false);
+        $table = $this->setup_ratings_table_with_filter_options($ratingallocate, true, false, 0);
         self::assertEquals(4, count($table->rawdata),
                 "Filtering the users to those with ratings should return 4 users.");
 
         // Count of users in total should be equal to 6.
-        $table = $this->setup_ratings_table_with_filter_options($ratingallocate, false, false);
+        $table = $this->setup_ratings_table_with_filter_options($ratingallocate, false, false, 0);
         self::assertEquals(6, count($table->rawdata),
                 "Filtering the users to those with or without ratings should return 6 users.");
 
         // Count of users with ratings where a allocation is necessary equal to 1.
-        $table = $this->setup_ratings_table_with_filter_options($ratingallocate, true, true);
+        $table = $this->setup_ratings_table_with_filter_options($ratingallocate, true, true, 0);
         self::assertEquals(1, count($table->rawdata),
                 'Filtering the users to those with ratings and' .
                 'where a allocation is necessary should return 1 user.');
 
         // Count of users with or without ratings where a allocation is necessary equal to 1.
-        $table = $this->setup_ratings_table_with_filter_options($ratingallocate, false, true);
+        $table = $this->setup_ratings_table_with_filter_options($ratingallocate, false, true, 0);
         self::assertEquals(2, count($table->rawdata),
                 'Filtering the users to those with or without ratings and' .
                 'where a allocation is necessary should return 2 users.');
 
     }
 
-    /**
+    public function test_ratings_table_groupfilter() {
+        $this->resetAfterTest();
+
+        $course = $this->getDataGenerator()->create_course();
+        $teacher = mod_ratingallocate_generator::create_user_and_enrol($this, $course, true);
+        $this->setUser($teacher);
+
+        // Create two groups.
+        $group1 = $this->getDataGenerator()->create_group(array(
+            'courseid' => $course,
+            'name' => 'group1'));
+        $group2 = $this->getDataGenerator()->create_group(array(
+            'courseid' => $course,
+            'name' => 'group2'));
+
+        // Add 1 member to each group, and 1 member to both groups.
+        $student1 = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+        groups_add_member($group1->id, $student1->id);
+        $student2 = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+        groups_add_member($group2->id, $student2->id);
+        $student3 = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+        groups_add_member($group1->id, $student3->id);
+        groups_add_member($group2->id, $student3->id);
+        $student4 = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+
+        // Setup ratingallocate instance.
+        $mod = mod_ratingallocate_generator::create_instance_with_choices($this, array('course' => $course), $this->get_choice_data());
+        $ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $teacher);
+
+        // Map choice titles to choice IDs, group names to group IDs.
+        $choices = $ratingallocate->get_rateable_choices();
+        $choiceidmap = $this->get_choice_map($ratingallocate, $choices);
+        $groupselections = $ratingallocate->get_group_selections();
+        $groupidmap = $this->get_group_map($ratingallocate, $groupselections);
+
+        /* Update choices with constraints depending on group:
+         * Choice A: only ratable by group1
+         * Choice B: only rateable by group2
+         * Choice C: ratable by all students
+         */
+        $ratingallocate->update_choice_groups($choiceidmap['Choice A'], array(
+            $groupidmap['group1']
+        ));
+        $ratingallocate->update_choice_groups($choiceidmap['Choice B'], array(
+            $groupidmap['group2']
+        ));
+
+        // Test the group filter only (set hidenorating and showalloccount to false).
+
+        // Count of users in total should be equal to 6.
+        $table = $this->setup_ratings_table_with_filter_options($ratingallocate, false, false, 0);
+        self::assertEquals(6, count($table->rawdata),
+            "Filtering the users to all course participants should return 6 users.");
+
+        // Count of users in group1 should be equal to 2.
+        $table = $this->setup_ratings_table_with_filter_options($ratingallocate, false, false, $groupidmap['group1']);
+        self::assertEquals(2, count($table->rawdata),
+            "Filtering the users to those in group1 should return 2 users.");
+
+        // Count of users in group1 should be equal to 2.
+        $table = $this->setup_ratings_table_with_filter_options($ratingallocate, false, false, $groupidmap['group2']);
+        self::assertEquals(2, count($table->rawdata),
+            "Filtering the users to those in group2 should return 2 users.");
+
+        // Count of users in neither group used in the ratingallocate activity should be equal to 3.
+        $table = $this->setup_ratings_table_with_filter_options($ratingallocate, false, false, -1);
+        self::assertEquals(3, count($table->rawdata),
+            "Filtering the users to those in neither group should return 3 users.");
+    }
+
+        /**
      * Removes the allocation for one existing user in course.
      * Enrols one new user wihtout rating or allocations.
      * Enrols one new user and creates an allocation for her.
@@ -156,16 +228,84 @@ class mod_ratingallocate_processor_test extends \advanced_testcase {
      * @param mixed $ratingallocate ratingallocate
      * @param $hidenorating bool
      * @param $showallocnecessary bool
+     * @param $groupselect int
      * @return \mod_ratingallocate\ratings_and_allocations_table
      */
-    private function setup_ratings_table_with_filter_options($ratingallocate, $hidenorating, $showallocnecessary) {
+    private function setup_ratings_table_with_filter_options($ratingallocate, $hidenorating, $showallocnecessary, $groupselect) {
         // Create and set up the flextable for ratings and allocations.
         $choices = $ratingallocate->get_rateable_choices();
         $table = new \mod_ratingallocate\ratings_and_allocations_table($ratingallocate->get_renderer(),
                 array(), $ratingallocate, 'show_alloc_table', 'mod_ratingallocate_test', false);
-        $table->setup_table($choices, $hidenorating, $showallocnecessary);
+        $table->setup_table($choices, $hidenorating, $showallocnecessary, $groupselect);
 
         return $table;
     }
 
+    /**
+     * Define custom choices for the ratingallocate activity
+     *
+     * @return array
+     */
+    private function get_choice_data() {
+        $choicedata = array();
+        $choice1 = array(
+            'title' => "Choice A",
+            'explanation' => "Ratable by group1",
+            'maxsize' => 10,
+            'active' => true,
+            'usegroups' => true
+        );
+        $choicedata[] = $choice1;
+        $choice2 = array(
+            'title' => "Choice B",
+            'explanation' => "Ratable by group2",
+            'maxsize' => 10,
+            'active' => true,
+            'usegroups' => true
+        );
+        $choicedata[] = $choice2;
+        $choice3 = array(
+            'title' => "Choice C",
+            'explanation' => "Ratable by all students",
+            'maxsize' => 10,
+            'active' => true,
+            'usegroups' => false
+        );
+        $choicedata[] = $choice3;
+        return $choicedata;
+    }
+
+    /**
+     * Helper function - Map choice titles to IDs
+     *
+     * @param array $choices
+     *
+     * @return array
+     */
+    private function get_choice_map($ratingallocate, $choices = null) {
+        if (!$choices) {
+            $choices = $ratingallocate->get_rateable_choices();
+        }
+        $choiceidmap = array_flip(array_map(
+            function($a) {
+                return $a->title;
+            },
+            $choices));
+        return $choiceidmap;
+    }
+
+    /**
+     * Helper function - Map group selection names to IDs
+     *
+     * @param array $groups
+     *
+     * @return array
+     */
+    private function get_group_map($ratingallocate, $groupselections = null) {
+        if (!$groupselections) {
+            $groupselections = $ratingallocate->get_group_selections();
+        }
+        $groupidmap = array_flip($groupselections);
+        return $groupidmap;
+    }
 }

--- a/tests/mod_ratingallocate_processor_test.php
+++ b/tests/mod_ratingallocate_processor_test.php
@@ -199,7 +199,7 @@ class mod_ratingallocate_processor_test extends \advanced_testcase {
             "Filtering the users to those in neither group should return 3 users.");
     }
 
-        /**
+    /**
      * Removes the allocation for one existing user in course.
      * Enrols one new user wihtout rating or allocations.
      * Enrols one new user and creates an allocation for her.

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023052600;        // The current module version (Date: YYYYMMDDXX).
+$plugin->version   = 2023060600;        // The current module version (Date: YYYYMMDDXX)
 $plugin->requires = 2020061500;         // Requires Moodle 3.9+.
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 'v4.2-r1';

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023060600;        // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2023062000;        // The current module version (Date: YYYYMMDDXX)
 $plugin->requires = 2020061500;         // Requires Moodle 3.9+.
 $plugin->maturity = MATURITY_STABLE;
 $plugin->release = 'v4.2-r1';


### PR DESCRIPTION
Adds a group filter to the manual allocation form in order to filter course participants according to the groups they are in, and ratable choices by groups that had the ability to access them.
