### PR TITLE
Fix core test core_calendar\container_test

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -174,13 +174,13 @@ function ratingallocate_delete_instance($id) {
         'ratingallocateid' => $ratingallocate->id
             ), '', 'id'));
 
-    list ($insql, $params) = $DB->get_in_or_equal($deleteids);
-
-    $DB->delete_records_select('ratingallocate_group_choices',
+    if (!empty($deleteids)) {
+        list ($insql, $params) = $DB->get_in_or_equal($deleteids);
+        $DB->delete_records_select('ratingallocate_group_choices',
             'choiceid ' . $insql, $params);
-
-    $DB->delete_records_select('ratingallocate_ch_gengroups',
-        'choiceid ' . $insql, $params);
+        $DB->delete_records_select('ratingallocate_ch_gengroups',
+            'choiceid ' . $insql, $params);
+    }
 
     $DB->delete_records('ratingallocate_groupings', array(
         'ratingallocateid' => $ratingallocate->id


### PR DESCRIPTION
Currently, mod_ratingallocate makes a core phpunit test fail: `core_calendar\container_test::test_delete_module_delete_events`

To reproduce run `phpunit --filter=test_delete_module_delete_events`.

This patch fixes that.

If you want to do me a favor... I would be happy if you could push a version bump into master after this, so we can switch back to the upstream repository and stop maintaining our own fork, TIA! ;-)