### PR TITLE
php 8.2 deprecation warnings fixed #288

### DIFF
--- a/tests/mod_ratingallocate_allocate_unrated_test.php
+++ b/tests/mod_ratingallocate_allocate_unrated_test.php
@@ -38,6 +38,27 @@ require_once(__DIR__ . '/../locallib.php');
  */
 class mod_ratingallocate_allocate_unrated_test extends \advanced_testcase {
 
+    /** @var stdClass Course object. */
+    private stdClass $course;
+    /** @var stdClass Enrolled teacher. */
+    private stdClass $teacher;
+    /** @var stdClass Green group. */
+    private stdClass $green;
+    /** @var stdClass Blue group. */
+    private stdClass $blue;
+    /** @var stdClass Red group. */
+    private stdClass $red;
+    /** @var array Students in the green group. */
+    private array $studentsgreen = [];
+    /** @var array Students in the blue group. */
+    private array $studentsblue = [];
+    /** @var array Students in the red group. */
+    private array $studentsred = [];
+    /** @var array Students belonging to no group. */
+    private array $studentsnogroup = [];
+    /** @var object Rating allocate object. */
+    private object $ratingallocate;
+
     protected function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);


### PR DESCRIPTION
In this pull request, I've made modifications to the mod_ratingallocate_allocate_unrated_test class to avoid deprecation warnings under PHP 8.2. Specifically, properties that were previously created dynamically have been assigned as class attributes to comply with PHP 8.2 standards.

Changes:

- Adding explicit attribute declarations for all properties that were dynamically generated before.

- Ensuring that the class remains compatible with PHP 8.2 without compromising functionality.

These changes improve the clarity of the code and prevent potential issues that could arise from the dynamic creation of properties in future PHP versions.