### PR TITLE
#312 Fix missing suffix of completion rules

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -363,7 +363,7 @@ class mod_ratingallocate_mod_form extends moodleform_mod {
      */
     protected function get_suffixed_name(string $fieldname): string {
         // Counterintuitively don't use function get_suffix(), since data isn't saved correctly in DB otherwise.
-        return 'completion' . $fieldname;
+        return 'completion' . $fieldname. '_' .self::MOD_NAME;
     }
 
     /**


### PR DESCRIPTION
Due to the missing suffix, the form elements of custom completion rules of module ratingallocate has been removed from the form.
![missing suffix](https://github.com/user-attachments/assets/bfaed958-6e50-4902-9ff6-bbf49c49d2dd)

Solution: The returned result of the function `get_suffixed_name` should really be appended with the module name
![missing suffix fixed](https://github.com/user-attachments/assets/143ccd65-8bfd-4384-8f8d-697fd66bb02a)
